### PR TITLE
Transform inputs to `pdf`/`cdf` for gaussian multivariate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean-pyc: ## remove Python file artifacts
 .PHONY: clean-docs
 clean-docs: ## remove previously built docs
 	rm -f docs/api/*.rst
-	rm -f docs/tutorials/*
+	rm -rf docs/tutorials/*
 	-$(MAKE) -C docs clean 2>/dev/null  # this fails if sphinx is not yet installed
 
 .PHONY: clean-coverage
@@ -112,7 +112,7 @@ test: ## run tests quickly with the default Python
 
 .PHONY: test-all
 test-all: ## run tests on every Python version with tox
-	tox
+	tox -r
 
 .PHONY: coverage
 coverage: ## check code coverage quickly with the default Python

--- a/copulas/multivariate/base.py
+++ b/copulas/multivariate/base.py
@@ -17,10 +17,6 @@ class Multivariate(object):
         """Fit a model to the data and update the parameters."""
         raise NotImplementedError
 
-    def infer(self, values):
-        """Predict data from a subset of values."""
-        raise NotImplementedError
-
     def probability_density(self, X):
         """Return probability density of model."""
         raise NotImplementedError

--- a/copulas/multivariate/gaussian.py
+++ b/copulas/multivariate/gaussian.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
-from copulas import check_valid_values, get_instance, get_qualified_name, random_state, store_args
+from copulas import (
+    EPSILON, check_valid_values, get_instance, get_qualified_name, random_state, store_args)
 from copulas.multivariate.base import Multivariate
 from copulas.univariate import Univariate
 
@@ -54,10 +55,7 @@ class GaussianMultivariate(Multivariate):
         U = list()
         for column_name, distrib in self.distribs.items():
             column = X[column_name]
-            if distrib.constant_value is not None:
-                U.append(np.ones(column.shape) / 2.0)
-            else:
-                U.append(distrib.cdf(column))
+            U.append(distrib.cdf(column).clip(EPSILON, 1 - EPSILON))
 
         return stats.norm.ppf(np.column_stack(U))
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.md') as history_file:
 install_requires = [
     'numpy>=1.13.1,<1.17',
     'pandas>=0.22.0,<0.25',
-    'scipy>=0.19.1,<1.3',
+    'scipy>=1.0,<1.3',
     'exrex>=0.10.5,<0.11',
     'matplotlib>=2.2.2,<4',
     'boto3>=1.7.47,<1.10',

--- a/tests/copulas/multivariate/test_gaussian_copula.py
+++ b/tests/copulas/multivariate/test_gaussian_copula.py
@@ -167,14 +167,14 @@ class TestGaussianCopula(TestCase):
         copula = GaussianMultivariate(
             distribution='copulas.univariate.gaussian.GaussianUnivariate')
         copula.fit(self.data)
-        X = np.array([[0., 0., 0.]])
-        expected_result = 0.059566912334560594
+        X = np.array([2000., 200., 0.])
+        expected_result = 0.031163598715950383
 
         # Run
         result = copula.probability_density(X)
 
         # Check
-        assert result == expected_result
+        self.assertAlmostEqual(result, expected_result)
 
     def test_cumulative_distribution_fit_df_call_np_array(self):
         """Cumulative_density integrates the probability density along the given values."""
@@ -182,8 +182,8 @@ class TestGaussianCopula(TestCase):
         copula = GaussianMultivariate(
             distribution='copulas.univariate.gaussian.GaussianUnivariate')
         copula.fit(self.data)
-        X = np.array([1., 1., 1.])
-        expected_result = 0.5822020991592192
+        X = np.array([2000., 200., 1.])
+        expected_result = 0.4460456536217443
 
         # Run
         result = copula.cumulative_distribution(X)
@@ -197,8 +197,8 @@ class TestGaussianCopula(TestCase):
         copula = GaussianMultivariate(
             distribution='copulas.univariate.gaussian.GaussianUnivariate')
         copula.fit(self.data.values)
-        X = np.array([1., 1., 1.])
-        expected_result = 0.5822020991592192
+        X = np.array([2000., 200., 1.])
+        expected_result = 0.4460456536217443
 
         # Run
         result = copula.cumulative_distribution(X)
@@ -212,28 +212,14 @@ class TestGaussianCopula(TestCase):
         copula = GaussianMultivariate(
             distribution='copulas.univariate.gaussian.GaussianUnivariate')
         copula.fit(self.data.values)
-        X = pd.Series([1., 1., 1.])
-        expected_result = 0.5822020991592192
+        X = np.array([2000., 200., 1.])
+        expected_result = 0.4460456536217443
 
         # Run
         result = copula.cumulative_distribution(X)
 
         # Check
         assert np.isclose(result, expected_result).all().all()
-
-    def test_get_lower_bounds(self):
-        """get_lower_bounds returns the point from where cut the tail of the infinite integral."""
-        # Setup
-        copula = GaussianMultivariate(
-            distribution='copulas.univariate.gaussian.GaussianUnivariate')
-        copula.fit(self.data)
-        expected_result = -3.104256111232535
-
-        # Run
-        result = copula.get_lower_bound()
-
-        # Check
-        assert result == expected_result
 
     def test_deprecation_warnings(self):
         """After fitting, Gaussian copula can produce new samples warningless."""

--- a/tests/copulas/multivariate/test_gaussian_copula.py
+++ b/tests/copulas/multivariate/test_gaussian_copula.py
@@ -1,12 +1,12 @@
 import warnings
+from collections import OrderedDict
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
-from scipy import stats
 
-from copulas import EPSILON, get_qualified_name
+from copulas import get_qualified_name
 from copulas.multivariate.gaussian import GaussianMultivariate
 from tests import compare_nested_dicts
 
@@ -566,20 +566,25 @@ class TestGaussianCopula(TestCase):
         dist_a.cdf.return_value = np.array([0])
         dist_b = Mock()
         dist_b.cdf.return_value = np.array([0.3])
-        gm.distribs = {
-            'a': dist_a,
-            'b': dist_b,
-        }
+        gm.distribs = OrderedDict((
+            ('a', dist_a),
+            ('b', dist_b),
+        ))
 
         # Run
-        returned = gm._transform_to_normal(np.array([3, 5]))
+        data = np.array([
+            [3, 5],
+        ])
+        returned = gm._transform_to_normal(data)
 
         # Check
-        data = np.array([
-            [EPSILON, 0.3],
+        # Failures may occurr on different cpytonn implementations
+        # with different float precision values.
+        # If that happens, atol might need to be increased
+        expected = np.array([
+            [-5.166579, -0.524401],
         ])
-        expected = stats.norm.ppf(data)
-        np.testing.assert_allclose(expected, returned)
+        np.testing.assert_allclose(returned, expected, atol=1e-6)
 
         assert dist_a.cdf.call_count == 1
         expected = np.array([3])
@@ -598,10 +603,10 @@ class TestGaussianCopula(TestCase):
         dist_a.cdf.return_value = np.array([0, 0.5, 1])
         dist_b = Mock()
         dist_b.cdf.return_value = np.array([0.3, 0.5, 0.7])
-        gm.distribs = {
-            'a': dist_a,
-            'b': dist_b,
-        }
+        gm.distribs = OrderedDict((
+            ('a', dist_a),
+            ('b', dist_b),
+        ))
 
         # Run
         data = np.array([
@@ -612,12 +617,15 @@ class TestGaussianCopula(TestCase):
         returned = gm._transform_to_normal(data)
 
         # Check
-        expected = stats.norm.ppf(np.array([
-            [EPSILON, 0.3],
-            [0.5, 0.5],
-            [1 - EPSILON, 0.7]
-        ]))
-        np.testing.assert_allclose(returned, expected)
+        # Failures may occurr on different cpytonn implementations
+        # with different float precision values.
+        # If that happens, atol might need to be increased
+        expected = np.array([
+            [-5.166579, -0.524401],
+            [0.0, 0.0],
+            [5.166579, 0.524401]
+        ])
+        np.testing.assert_allclose(returned, expected, atol=1e-6)
 
         assert dist_a.cdf.call_count == 1
         expected = np.array([3, 4, 5])
@@ -636,20 +644,23 @@ class TestGaussianCopula(TestCase):
         dist_a.cdf.return_value = np.array([0])
         dist_b = Mock()
         dist_b.cdf.return_value = np.array([0.3])
-        gm.distribs = {
-            'a': dist_a,
-            'b': dist_b,
-        }
+        gm.distribs = OrderedDict((
+            ('a', dist_a),
+            ('b', dist_b),
+        ))
 
         # Run
         data = pd.Series({'a': 3, 'b': 5})
         returned = gm._transform_to_normal(data)
 
         # Check
-        expected = stats.norm.ppf(np.array([
-            [EPSILON, 0.3],
-        ]))
-        np.testing.assert_allclose(expected, returned)
+        # Failures may occurr on different cpytonn implementations
+        # with different float precision values.
+        # If that happens, atol might need to be increased
+        expected = np.array([
+            [-5.166579, -0.524401],
+        ])
+        np.testing.assert_allclose(returned, expected, atol=1e-6)
 
         assert dist_a.cdf.call_count == 1
         expected = np.array([3])
@@ -668,10 +679,10 @@ class TestGaussianCopula(TestCase):
         dist_a.cdf.return_value = np.array([0, 0.5, 1])
         dist_b = Mock()
         dist_b.cdf.return_value = np.array([0.3, 0.5, 0.7])
-        gm.distribs = {
-            'a': dist_a,
-            'b': dist_b,
-        }
+        gm.distribs = OrderedDict((
+            ('a', dist_a),
+            ('b', dist_b),
+        ))
 
         # Run
         data = pd.DataFrame({
@@ -681,12 +692,15 @@ class TestGaussianCopula(TestCase):
         returned = gm._transform_to_normal(data)
 
         # Check
-        expected = stats.norm.ppf(np.array([
-            [EPSILON, 0.3],
-            [0.5, 0.5],
-            [1 - EPSILON, 0.7]
-        ]))
-        np.testing.assert_allclose(returned, expected)
+        # Failures may occurr on different cpytonn implementations
+        # with different float precision values.
+        # If that happens, atol might need to be increased
+        expected = np.array([
+            [-5.166579, -0.524401],
+            [0.0, 0.0],
+            [5.166579, 0.524401]
+        ])
+        np.testing.assert_allclose(returned, expected, atol=1e-6)
 
         assert dist_a.cdf.call_count == 1
         expected = np.array([3, 4, 5])


### PR DESCRIPTION
Resolve #147 

The inputs to `pdf`/`cdf` are no longer expected to be the result of transforming X to uniform and then to gaussian. Instead, it directly takes X now. In addition, it also uses a more numerically stable implementation of `cdf` provided by scipy. Also, fixes a bug where off-diagonal covariances were being zero'd out.