### PR TITLE
Improve Univariates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,15 +108,15 @@ fix-lint: ## fix lint issues using autoflake, autopep8, and isort
 
 .PHONY: test
 test: ## run tests quickly with the default Python
-	python -m pytest --cov=copulas
+	python -m pytest --disable-warnings --cov=copulas
 
 .PHONY: test-unit
 test-unit: ## run tests quickly with the default Python
-	python -m pytest --cov=copulas tests/unit
+	python -m pytest --disable-warnings --cov=copulas tests/unit
 
 .PHONY: test-numerical
 test-numerical: ## run tests quickly with the default Python
-	python -m pytest --cov=copulas tests/numerical
+	python -m pytest --disable-warnings --cov=copulas tests/numerical
 
 .PHONY: test-all
 test-all: ## run tests on every Python version with tox

--- a/copulas/univariate/beta.py
+++ b/copulas/univariate/beta.py
@@ -1,114 +1,37 @@
 import numpy as np
 from scipy.stats import beta
 
-from copulas import check_valid_values, store_args
-from copulas.univariate.base import BoundedType, ParametricType, ScipyWrapper
+from copulas.univariate.base import BoundedType, ParametricType, ScipyModel
 
 
-class BetaUnivariate(ScipyWrapper):
+class BetaUnivariate(ScipyModel):
     """Wrapper around scipy.stats.beta.
 
     Documentation: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.beta.html
     """
 
-    model_class = 'beta'
-    unfittable_model = True
-    probability_density = 'pdf'
-    cumulative_distribution = 'cdf'
-    percent_point = 'ppf'
-    sample = 'rvs'
-
-    fitted = False
-    constant_value = None
-
     PARAMETRIC = ParametricType.PARAMETRIC
     BOUNDED = BoundedType.BOUNDED
+    MODEL_CLASS = beta
 
-    @store_args
-    def __init__(self):
-        self.a = None
-        self.b = None
-        self.loc = None
-        self.scale = None
-
-    def _get_model(self):
-        return beta(self.a, self.b, loc=self.loc, scale=self.scale)
-
-    def _fit_beta(self, X):
-        """Fit the beta parameters to the data.
-        """
-        self.loc = np.min(X)
-        self.scale = np.max(X) - self.loc
-        self.a, self.b, _, _ = beta.fit(X, loc=self.loc, scale=self.scale)
-        self.model = self._get_model()
-
-    @check_valid_values
-    def fit(self, X):
-        """Fit scipy model to an array of values.
-
-        Args:
-            X(`np.ndarray` or `pd.DataFrame`):  Datapoints to be estimated from. Must be 1-d
-
-        Returns:
-            None
-        """
-
-        self.constant_value = self._get_constant_value(X)
-
-        if self.constant_value is None:
-            self._fit_beta(X)
-            self._replace_methods()
-        else:
-            self._replace_constant_methods()
-
-        self.fitted = True
-
-    @classmethod
-    def from_dict(cls, parameters):
-        """Set attributes with provided values.
-
-        Args:
-            parameters(dict): Dictionary containing instance parameters.
-
-        Returns:
-            Truncnorm: Instance populated with given parameters.
-        """
-        instance = cls()
-        instance.fitted = parameters['fitted']
-
-        if instance.fitted:
-            instance.a = parameters['a']
-            instance.b = parameters['b']
-            instance.loc = parameters['loc']
-            instance.scale = parameters['scale']
-
-            if instance.scale == 0.0:
-                instance.constant_value = instance.loc
-                instance._replace_constant_methods()
-
-            else:
-                instance.model = instance._get_model()
-                instance._replace_methods()
-
-        return instance
-
-    def _fit_params(self):
-        """Return attributes from self.model to serialize.
-
-        Returns:
-            dict: Parameters to recreate self.model in its current fit status.
-        """
-        if self.constant_value is not None:
-            return {
-                'a': 0.0,
-                'b': 0.0,
-                'loc': self.constant_value,
-                'scale': 0.0,
-            }
-
-        return {
-            'a': self.a,
-            'b': self.b,
-            'loc': self.loc,
-            'scale': self.scale,
+    def _fit_constant(self, X):
+        self._params = {
+            'a': 1.0,
+            'b': 1.0,
+            'loc': np.unique(X)[0],
+            'scale': 0.0,
         }
+
+    def _fit(self, X):
+        loc = np.min(X)
+        scale = np.max(X) - loc
+        a, b = beta.fit(X, loc=loc, scale=scale)[0:2]
+        self._params = {
+            'loc': loc,
+            'scale': scale,
+            'a': a,
+            'b': b
+        }
+
+    def _is_constant(self):
+        return self._params['scale'] == 0

--- a/copulas/univariate/gamma.py
+++ b/copulas/univariate/gamma.py
@@ -1,106 +1,33 @@
+import numpy as np
 from scipy.stats import gamma
 
-from copulas import check_valid_values, store_args
-from copulas.univariate.base import BoundedType, ParametricType, ScipyWrapper
+from copulas.univariate.base import BoundedType, ParametricType, ScipyModel
 
 
-class GammaUnivariate(ScipyWrapper):
+class GammaUnivariate(ScipyModel):
     """Wrapper around scipy.stats.gamma.
 
     Documentation: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gamma.html
     """
 
-    model_class = 'gamma'
-    unfittable_model = True
-    probability_density = 'pdf'
-    cumulative_distribution = 'cdf'
-    percent_point = 'ppf'
-    sample = 'rvs'
-
-    fitted = False
-    constant_value = None
-
     PARAMETRIC = ParametricType.PARAMETRIC
     BOUNDED = BoundedType.SEMI_BOUNDED
+    MODEL_CLASS = gamma
 
-    @store_args
-    def __init__(self):
-        self.a = None
-        self.loc = None
-        self.scale = None
-
-    def _get_model(self):
-        return gamma(self.a, loc=self.loc, scale=self.scale)
-
-    def _fit_gamma(self, X):
-        """Fit the gamma parameters to the data."""
-        self.a, self.loc, self.scale = gamma.fit(X)
-        self.model = self._get_model()
-
-    @check_valid_values
-    def fit(self, X):
-        """Fit scipy model to an array of values.
-
-        Args:
-            X(`np.ndarray` or `pd.DataFrame`):  Datapoints to be estimated from. Must be 1-d
-
-        Returns:
-            None
-        """
-
-        self.constant_value = self._get_constant_value(X)
-
-        if self.constant_value is None:
-            self._fit_gamma(X)
-            self._replace_methods()
-        else:
-            self._replace_constant_methods()
-
-        self.fitted = True
-
-    @classmethod
-    def from_dict(cls, parameters):
-        """Set attributes with provided values.
-
-        Args:
-            parameters(dict): Dictionary containing instance parameters.
-
-        Returns:
-            Truncnorm: Instance populated with given parameters.
-        """
-        instance = cls()
-        instance.fitted = parameters['fitted']
-
-        if instance.fitted:
-            instance.a = parameters['a']
-            instance.loc = parameters['loc']
-            instance.scale = parameters['scale']
-
-            if instance.scale == 0.0:
-                instance.constant_value = instance.loc
-                instance._replace_constant_methods()
-
-            else:
-                instance.model = instance._get_model()
-                instance._replace_methods()
-
-        return instance
-
-    def _fit_params(self):
-        """Return attributes from self.model to serialize.
-
-        Returns:
-            dict: Parameters to recreate self.model in its current fit status.
-        """
-        if self.constant_value is not None:
-            return {
-                'a': 0,
-                'loc': self.constant_value,
-                'scale': 0.0,
-            }
-
-        return {
-            'a': self.a,
-            'loc': self.loc,
-            'scale': self.scale,
+    def _fit_constant(self, X):
+        self._params = {
+            'a': 0.0,
+            'loc': np.unique(X)[0],
+            'scale': 0.0,
         }
+
+    def _fit(self, X):
+        a, loc, scale = gamma.fit(X)
+        self._params = {
+            'a': a,
+            'loc': loc,
+            'scale': scale,
+        }
+
+    def _is_constant(self):
+        return self._params['scale'] == 0

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -1,139 +1,28 @@
-import logging
-
 import numpy as np
-import pandas as pd
 from scipy.stats import norm
 
-from copulas import check_valid_values, random_state, store_args
-from copulas.univariate.base import BoundedType, ParametricType, Univariate
-
-LOGGER = logging.getLogger(__name__)
+from copulas.univariate.base import BoundedType, ParametricType, ScipyModel
 
 
-class GaussianUnivariate(Univariate):
+class GaussianUnivariate(ScipyModel):
     """Gaussian univariate model."""
-
-    fitted = False
 
     PARAMETRIC = ParametricType.PARAMETRIC
     BOUNDED = BoundedType.UNBOUNDED
 
-    @store_args
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.name = None
-        self.mean = None
-        self.std = None
+    MODEL_CLASS = norm
 
-    def __str__(self):
-        details = [self.name, self.mean, self.std]
-        return (
-            'Distribution Type: Gaussian\n'
-            'Variable name: {}\n'
-            'Mean: {}\n'
-            'Standard deviation: {}'.format(*details)
-        )
-
-    @check_valid_values
-    def fit(self, X):
-        """Fit the model.
-
-        Arguments:
-            X: `np.ndarray` of shape (n, 1).
-
-        Returns:
-            None
-        """
-        if isinstance(X, (pd.Series, pd.DataFrame)):
-            self.name = X.name
-
-        self.constant_value = self._get_constant_value(X)
-
-        if self.constant_value is None:
-            self.mean = np.mean(X)
-            self.std = np.std(X)
-
-        else:
-            self._replace_constant_methods()
-
-        self.fitted = True
-
-    def probability_density(self, X):
-        """Compute probability density.
-
-        Arguments:
-            X: `np.ndarray` of shape (n, 1).
-
-        Returns:
-            np.ndarray
-        """
-        self.check_fit()
-        return norm.pdf(X, loc=self.mean, scale=self.std)
-
-    def cumulative_distribution(self, X):
-        """Cumulative distribution function for gaussian distribution.
-
-        Arguments:
-            X: `np.ndarray` of shape (n, 1).
-
-        Returns:
-            np.ndarray: Cumulative density for X.
-        """
-        self.check_fit()
-        return norm.cdf(X, loc=self.mean, scale=self.std)
-
-    def percent_point(self, U):
-        """Given a cumulated distribution value, returns a value in original space.
-
-        Arguments:
-            U: `np.ndarray` of shape (n, 1) and values in [0,1]
-
-        Returns:
-            `np.ndarray`: Estimated values in original space.
-        """
-        self.check_fit()
-        return norm.ppf(U, loc=self.mean, scale=self.std)
-
-    @random_state
-    def sample(self, num_samples=1):
-        """Returns new data point based on model.
-
-        Arguments:
-            n_samples: `int`
-
-        Returns:
-            np.ndarray: Generated samples
-        """
-        self.check_fit()
-        return np.random.normal(self.mean, self.std, num_samples)
-
-    def _fit_params(self):
-        if self.constant_value is not None:
-            return {
-                'mean': self.constant_value,
-                'std': 0
-            }
-
-        return {
-            'mean': self.mean,
-            'std': self.std,
+    def _fit_constant(self, X):
+        self._params = {
+            'loc': np.unique(X)[0],
+            'scale': 0
         }
 
-    @classmethod
-    def from_dict(cls, copula_dict):
-        """Set attributes with provided values."""
-        instance = cls()
-        instance.fitted = copula_dict['fitted']
+    def _fit(self, X):
+        self._params = {
+            'loc': np.mean(X),
+            'scale': np.std(X)
+        }
 
-        if not instance.fitted:
-            return instance
-
-        std = copula_dict['std']
-        if std == 0:
-            instance.constant_value = copula_dict['mean']
-
-        else:
-            instance.mean = copula_dict['mean']
-            instance.std = std
-
-        return instance
+    def _is_constant(self):
+        return self._params['scale'] == 0

--- a/copulas/univariate/selection.py
+++ b/copulas/univariate/selection.py
@@ -5,6 +5,18 @@ from copulas import get_instance
 
 
 def select_univariate(X, candidates):
+    """Select the best univariate class for this data.
+
+    Args:
+        X (pandas.DataFrame):
+            Data for which be best univariate must be found.
+        candidates (list[Univariate]):
+            List of Univariate subclasses (or instances of those) to choose from.
+
+    Returns:
+        Univariate:
+            Instance of the selected candidate.
+    """
     best_ks = np.inf
     best_model = None
     for model in candidates:

--- a/tests/end-to-end/multivariate/test_vine.py
+++ b/tests/end-to-end/multivariate/test_vine.py
@@ -59,7 +59,6 @@ class TestGaussian(TestCase):
         sampled_data = model2.sample(10)
         assert sampled_data.shape == (10, 3)
 
-    @pytest.mark.xfail
     def test_save_load(self):
         data = sample_trivariate_xyz()
         model = VineCopula('direct')

--- a/tests/end-to-end/multivariate/test_vine.py
+++ b/tests/end-to-end/multivariate/test_vine.py
@@ -2,8 +2,6 @@ import os
 import tempfile
 from unittest import TestCase
 
-import pytest
-
 from copulas.datasets import sample_trivariate_xyz
 from copulas.multivariate import VineCopula
 

--- a/tests/end-to-end/univariate/test_beta.py
+++ b/tests/end-to-end/univariate/test_beta.py
@@ -3,7 +3,6 @@ import tempfile
 from unittest import TestCase
 
 import numpy as np
-import pytest
 from scipy.stats import beta
 
 from copulas.univariate import BetaUnivariate
@@ -23,10 +22,10 @@ class TestGaussian(TestCase):
         model = BetaUnivariate()
         model.fit(self.data)
 
-        np.testing.assert_allclose(model.loc, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.scale, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.a, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.b, 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['loc'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['scale'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['a'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['b'], 1.0, atol=0.1)
 
         sampled_data = model.sample(50)
 
@@ -42,7 +41,7 @@ class TestGaussian(TestCase):
         assert isinstance(sampled_data, np.ndarray)
         assert sampled_data.shape == (50, )
 
-        assert model.constant_value == 5
+        assert model._constant_value == 5
         np.testing.assert_equal(np.full(50, 5), model.sample(50))
 
     def test_pdf(self):
@@ -94,15 +93,13 @@ class TestGaussian(TestCase):
         params = model.to_dict()
 
         assert params == {
-            'fitted': True,
             'type': 'copulas.univariate.beta.BetaUnivariate',
             'loc': 5,
             'scale': 0,
-            'a': 0,
-            'b': 0
+            'a': 1,
+            'b': 1
         }
 
-    @pytest.mark.xfail
     def test_save_load(self):
         model = BetaUnivariate()
         model.fit(self.data)

--- a/tests/end-to-end/univariate/test_gamma.py
+++ b/tests/end-to-end/univariate/test_gamma.py
@@ -3,7 +3,6 @@ import tempfile
 from unittest import TestCase
 
 import numpy as np
-import pytest
 from scipy.stats import gamma
 
 from copulas.univariate import GammaUnivariate
@@ -23,9 +22,9 @@ class TestGaussian(TestCase):
         model = GammaUnivariate()
         model.fit(self.data)
 
-        np.testing.assert_allclose(model.loc, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.scale, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.a, 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['loc'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['scale'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['a'], 1.0, atol=0.1)
 
         sampled_data = model.sample(50)
 
@@ -41,7 +40,7 @@ class TestGaussian(TestCase):
         assert isinstance(sampled_data, np.ndarray)
         assert sampled_data.shape == (50, )
 
-        assert model.constant_value == 5
+        assert model._constant_value == 5
         np.testing.assert_equal(np.full(50, 5), model.sample(50))
 
     def test_pdf(self):
@@ -93,14 +92,12 @@ class TestGaussian(TestCase):
         params = model.to_dict()
 
         assert params == {
-            'fitted': True,
             'type': 'copulas.univariate.gamma.GammaUnivariate',
             'loc': 5,
             'scale': 0,
             'a': 0,
         }
 
-    @pytest.mark.xfail
     def test_save_load(self):
         model = GammaUnivariate()
         model.fit(self.data)

--- a/tests/end-to-end/univariate/test_gaussian.py
+++ b/tests/end-to-end/univariate/test_gaussian.py
@@ -3,7 +3,6 @@ import tempfile
 from unittest import TestCase
 
 import numpy as np
-import pytest
 from scipy.stats import norm
 
 from copulas.univariate import GaussianUnivariate
@@ -23,8 +22,8 @@ class TestGaussian(TestCase):
         model = GaussianUnivariate()
         model.fit(self.data)
 
-        np.testing.assert_allclose(model.mean, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.std, 0.5, atol=0.1)
+        np.testing.assert_allclose(model._params['loc'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['scale'], 0.5, atol=0.1)
 
         sampled_data = model.sample(50)
 
@@ -40,7 +39,7 @@ class TestGaussian(TestCase):
         assert isinstance(sampled_data, np.ndarray)
         assert sampled_data.shape == (50, )
 
-        assert model.constant_value == 5
+        assert model._constant_value == 5
         np.testing.assert_equal(np.full(50, 5), model.sample(50))
 
     def test_pdf(self):
@@ -92,13 +91,11 @@ class TestGaussian(TestCase):
         params = model.to_dict()
 
         assert params == {
-            'fitted': True,
             'type': 'copulas.univariate.gaussian.GaussianUnivariate',
-            'mean': 5,
-            'std': 0,
+            'loc': 5,
+            'scale': 0,
         }
 
-    @pytest.mark.xfail
     def test_save_load(self):
         model = GaussianUnivariate()
         model.fit(self.data)

--- a/tests/end-to-end/univariate/test_gaussian_kde.py
+++ b/tests/end-to-end/univariate/test_gaussian_kde.py
@@ -3,7 +3,6 @@ import tempfile
 from unittest import TestCase
 
 import numpy as np
-import pytest
 
 from copulas.datasets import sample_univariate_bimodal
 from copulas.univariate import GaussianKDE
@@ -37,7 +36,7 @@ class TestGaussian(TestCase):
         assert isinstance(sampled_data, np.ndarray)
         assert sampled_data.shape == (50, )
 
-        assert model.constant_value == 5
+        assert model._constant_value == 5
         np.testing.assert_equal(np.full(50, 5), model.sample(50))
 
     def test_pdf(self):
@@ -88,7 +87,6 @@ class TestGaussian(TestCase):
 
         params = model.to_dict()
 
-        assert params['fitted']
         assert params['type'] == 'copulas.univariate.gaussian_kde.GaussianKDE'
         assert len(params['dataset']) == 10
 
@@ -99,12 +97,10 @@ class TestGaussian(TestCase):
         params = model.to_dict()
 
         assert params == {
-            'fitted': True,
             'type': 'copulas.univariate.gaussian_kde.GaussianKDE',
             'dataset': [5] * 100
         }
 
-    @pytest.mark.xfail
     def test_save_load(self):
         model = GaussianKDE()
         model.fit(self.data)

--- a/tests/end-to-end/univariate/test_truncated_gaussian.py
+++ b/tests/end-to-end/univariate/test_truncated_gaussian.py
@@ -3,7 +3,6 @@ import tempfile
 from unittest import TestCase
 
 import numpy as np
-import pytest
 from scipy.stats import truncnorm
 
 from copulas.univariate import TruncatedGaussian
@@ -23,10 +22,10 @@ class TestGaussian(TestCase):
         model = TruncatedGaussian(min=1, max=5)
         model.fit(self.data)
 
-        np.testing.assert_allclose(model.mean, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.std, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.min, 1.0, atol=0.1)
-        np.testing.assert_allclose(model.max, 5.0, atol=0.1)
+        np.testing.assert_allclose(model._params['loc'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['scale'], 1.0, atol=0.1)
+        np.testing.assert_allclose(model._params['a'], 0.0, atol=0.1)
+        np.testing.assert_allclose(model._params['b'], 4.0, atol=0.1)
 
         sampled_data = model.sample(50)
 
@@ -42,7 +41,7 @@ class TestGaussian(TestCase):
         assert isinstance(sampled_data, np.ndarray)
         assert sampled_data.shape == (50, )
 
-        assert model.constant_value == 5
+        assert model._constant_value == 5
         np.testing.assert_equal(np.full(50, 5), model.sample(50))
 
     def test_pdf(self):
@@ -94,15 +93,13 @@ class TestGaussian(TestCase):
         params = model.to_dict()
 
         assert params == {
-            'fitted': True,
             'type': 'copulas.univariate.truncated_gaussian.TruncatedGaussian',
-            'mean': 5,
-            'std': 0,
-            'min': 5,
-            'max': 5,
+            'loc': 5,
+            'scale': 0,
+            'a': 5,
+            'b': 5,
         }
 
-    @pytest.mark.xfail
     def test_save_load(self):
         model = TruncatedGaussian()
         model.fit(self.data)

--- a/tests/unit/multivariate/test_gaussian.py
+++ b/tests/unit/multivariate/test_gaussian.py
@@ -212,8 +212,8 @@ class TestGaussianMultivariate(TestCase):
         for i, key in enumerate(self.data.columns):
             assert copula.columns[i] == key
             assert copula.univariates[i].__class__ == GaussianUnivariate
-            assert copula.univariates[i].mean == self.data[key].mean()
-            assert copula.univariates[i].std == np.std(self.data[key])
+            assert copula.univariates[i]._params['loc'] == self.data[key].mean()
+            assert copula.univariates[i]._params['scale'] == np.std(self.data[key])
 
         expected_covariance = copula._get_covariance(self.data)
         assert (copula.covariance == expected_covariance).all().all()
@@ -266,8 +266,8 @@ class TestGaussianMultivariate(TestCase):
 
         # Check
         for key, (column, univariate) in enumerate(zip(self.data.columns, copula.univariates)):
-            assert univariate.mean == np.mean(self.data[column])
-            assert univariate.std == np.std(self.data[column])
+            assert univariate._params['loc'] == np.mean(self.data[column])
+            assert univariate._params['scale'] == np.std(self.data[column])
 
         expected_covariance = copula._get_covariance(pd.DataFrame(self.data.values))
         assert (copula.covariance == expected_covariance).all().all()

--- a/tests/unit/univariate/test_base.py
+++ b/tests/unit/univariate/test_base.py
@@ -1,9 +1,8 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
 
 import numpy as np
 
-from copulas.univariate.base import BoundedType, ParametricType, ScipyWrapper, Univariate
+from copulas.univariate.base import BoundedType, ParametricType, Univariate
 from copulas.univariate.beta import BetaUnivariate
 from copulas.univariate.gamma import GammaUnivariate
 from copulas.univariate.gaussian import GaussianUnivariate
@@ -79,79 +78,55 @@ class TestUnivariate(TestCase):
         """if constant values, replace methods."""
         # Setup
         distribution = Univariate()
-        replace_mock = MagicMock()
-        distribution._replace_constant_methods = replace_mock
 
         # Run
         distribution.fit(np.array([1, 1, 1, 1, 1]))
 
         # Assert
         assert distribution.fitted
-        assert distribution.constant_value == 1
-        replace_mock.assert_called_once_with()
+        assert distribution._instance._is_constant()
 
-    @patch('copulas.univariate.base.select_univariate')
-    def test_fit_not_contant(self, select_mock):
-        """if not constant call select_univariate and fit the returned instance.
-
-        Check that candidates are passed down to select_univariate
-        and that the returned instance is fitted on the input data.
-        """
+    def test_fit_not_constant(self):
+        """if constant values, replace methods."""
         # Setup
-        candidate = MagicMock()
-        candidates = [candidate]
-        distribution = Univariate(candidates)
+        distribution = Univariate()
 
         # Run
-        data = np.array([1, 2, 3, 4, 5])
-        distribution.fit(data)
+        distribution.fit(np.array([1, 2, 3, 4, 1]))
 
         # Assert
         assert distribution.fitted
-        assert distribution.constant_value is None
+        assert not distribution._instance._is_constant()
 
-        # candidates are passed down
-        assert select_mock.call_count == 1
-        expected_call = call(data, candidates)[1:]
-        actual_call = select_mock.call_args
-        compare_nested_iterables(expected_call, actual_call)
-
-        # the returned instance is fitted
-        instance = select_mock.return_value
-        assert instance.fit.call_count == 1
-        expected_call = call(data)[1:]
-        actual_call = instance.fit.call_args
-        compare_nested_iterables(expected_call, actual_call)
-
-    def test_get_constant_value(self):
-        """get_constant_value return the unique value of an array if it exists."""
+    def test_check_constant_value(self):
+        """check_constant_value return True if the array is constant."""
         # Setup
         X = np.array([1, 1, 1, 1])
-        expected_result = 1
 
         # Run
-        result = Univariate._get_constant_value(X)
+        uni = Univariate()
+        constant = uni._check_constant_value(X)
 
         # Check
-        assert result == expected_result
+        assert constant
 
-    def test_get_constant_value_non_constant(self):
-        """get_constant_value return None on non-constant arrays."""
+    def test_check_constant_value_non_constant(self):
+        """_check_constant_value returns False if the array is not constant."""
         # Setup
-        X = np.array(range(5))
-        expected_result = None
+        X = np.array([1, 2, 3, 4])
 
         # Run
-        result = Univariate._get_constant_value(X)
+        uni = Univariate()
+        constant = uni._check_constant_value(X)
 
         # Check
-        assert result is expected_result
+        assert not constant
 
-    def test__sample_sample(self):
+    def test__constant_sample(self):
         """_constant_sample returns a constant array of num_samples length."""
         # Setup
         instance = Univariate()
-        instance.constant_value = 15
+        instance._constant_value = 15
 
         expected_result = np.array([15, 15, 15, 15, 15])
 
@@ -165,7 +140,7 @@ class TestUnivariate(TestCase):
         """constant_cumulative_distribution returns only 0 and 1."""
         # Setup
         instance = Univariate()
-        instance.constant_value = 3
+        instance._constant_value = 3
 
         X = np.array([1, 2, 3, 4, 5])
         expected_result = np.array([0, 0, 1, 1, 1])
@@ -180,7 +155,7 @@ class TestUnivariate(TestCase):
         """constant_probability_density only is 1 in self.constant_value."""
         # Setup
         instance = Univariate()
-        instance.constant_value = 3
+        instance._constant_value = 3
 
         X = np.array([1, 2, 3, 4, 5])
         expected_result = np.array([0, 0, 1, 0, 0])
@@ -195,7 +170,7 @@ class TestUnivariate(TestCase):
         """constant_percent_point only is self.constant_value in non-zero probabilities."""
         # Setup
         instance = Univariate()
-        instance.constant_value = 3
+        instance._constant_value = 3
 
         X = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
         expected_result = np.array([3, 3, 3, 3, 3, 3])
@@ -205,235 +180,3 @@ class TestUnivariate(TestCase):
 
         # Check
         compare_nested_iterables(result, expected_result)
-
-
-class TestScipyWrapper(TestCase):
-
-    def test___init___valid_params(self):
-        """On init, self.model is set to None."""
-        # Setup
-        class ScipyWrapperSubclass(ScipyWrapper):
-            model_class = 'gaussian_kde'
-
-        # Run
-        instance = ScipyWrapperSubclass()
-
-        # Check
-        assert instance.model is None
-        assert instance.fitted is False
-        assert instance.constant_value is None
-
-    def test_fit_constant(self):
-        # Run
-        wrapper = ScipyWrapper()
-        wrapper.fit(np.zeros(5))
-
-        # Asserts
-        assert wrapper.fitted
-        assert wrapper.cumulative_distribution == wrapper._constant_cumulative_distribution
-        assert wrapper.percent_point == wrapper._constant_percent_point
-        assert wrapper.probability_density == wrapper._constant_probability_density
-        assert wrapper.sample == wrapper._constant_sample
-
-    @patch('copulas.univariate.base.scipy.stats')
-    def test_fit_fittable(self, stats_mock):
-        # Setup
-        class ScipyWrapperSubclass(ScipyWrapper):
-            model_class = 'dummy'
-            cumulative_distribution = 'cdf'
-            percent_point = 'ppf'
-            probability_density = 'pdf'
-            sample = 'rvs'
-
-        dummy = MagicMock()
-        stats_mock.dummy.return_value = dummy
-
-        # Run
-        data = np.array(range(5))
-        wrapper = ScipyWrapperSubclass()
-        wrapper.fit(data, 'some', 'args', some='kwargs')
-
-        # Asserts
-        stats_mock.dummy.assert_called_once_with(data, 'some', 'args', some='kwargs')
-        assert wrapper.model == dummy
-
-        assert wrapper.fitted
-        assert wrapper.cumulative_distribution == dummy.cdf
-        assert wrapper.percent_point == dummy.ppf
-        assert wrapper.probability_density == dummy.pdf
-        assert wrapper.sample == dummy.rvs
-
-    @patch('copulas.univariate.base.scipy.stats')
-    def test_fit_unfittable(self, stats_mock):
-        # Setup
-        class ScipyWrapperSubclass(ScipyWrapper):
-            unfittable_model = True
-            model_class = 'dummy'
-            cumulative_distribution = 'cdf'
-            percent_point = 'ppf'
-            probability_density = 'pdf'
-            sample = 'rvs'
-
-        dummy = MagicMock()
-        stats_mock.dummy.return_value = dummy
-
-        # Run
-        data = np.array(range(5))
-        wrapper = ScipyWrapperSubclass()
-        wrapper.fit(data, 'some', 'args', some='kwargs')
-
-        # Asserts
-        stats_mock.dummy.assert_called_once_with('some', 'args', some='kwargs')
-        assert wrapper.model == dummy
-
-        assert wrapper.fitted
-        assert wrapper.cumulative_distribution == dummy.cdf
-        assert wrapper.percent_point == dummy.ppf
-        assert wrapper.probability_density == dummy.pdf
-        assert wrapper.sample == dummy.rvs
-
-    @patch('copulas.univariate.base.scipy.stats', autospec=True)
-    def test_probability_density(self, scipy_mock):
-        """probability_density calls to the mapped method of model."""
-        # Setup
-        class ScipyWrapperSubclass(ScipyWrapper):
-            model_class = 'mock_model'
-            probability_density = 'pdf'
-            cumulative_distribution = None
-            percent_point = None
-            sample = None
-
-        model_instance_mock = MagicMock(spec=['pdf'])
-        model_instance_mock.pdf.return_value = 'pdf value'
-        model_class_mock = MagicMock()
-        model_class_mock.return_value = model_instance_mock
-        scipy_mock.mock_model = model_class_mock
-
-        fit_data = np.array(range(5))
-        instance = ScipyWrapperSubclass()
-        instance.fit(fit_data)
-
-        call_data = np.array([0.0])
-        expected_result = 'pdf value'
-
-        # Run
-        result = instance.probability_density(call_data)
-
-        # Check
-        assert result == expected_result
-
-        scipy_mock.assert_not_called()
-        model_class_mock.assert_called_once_with(fit_data)
-        model_instance_mock.assert_not_called()
-        model_instance_mock.pdf.assert_called_once_with(call_data)
-
-    @patch('copulas.univariate.base.scipy.stats', autospec=True)
-    def test_cumulative_distribution(self, scipy_mock):
-        """cumulative_distribution calls to the mapped method of model."""
-        # Setup
-        class ScipyWrapperSubclass(ScipyWrapper):
-            model_class = 'mock_model'
-            probability_density = None
-            cumulative_distribution = 'cdf'
-            percent_point = None
-            sample = None
-
-        model_instance_mock = MagicMock(spec=['cdf'])
-        model_instance_mock.cdf.return_value = 'cdf value'
-        model_class_mock = MagicMock()
-        model_class_mock.return_value = model_instance_mock
-        scipy_mock.mock_model = model_class_mock
-
-        fit_data = np.array(range(5))
-        instance = ScipyWrapperSubclass()
-        instance.fit(fit_data)
-
-        call_data = np.array([0.0])
-        expected_result = 'cdf value'
-
-        # Run
-        result = instance.cumulative_distribution(call_data)
-
-        # Check
-        assert result == expected_result
-
-        scipy_mock.assert_not_called()
-        model_class_mock.assert_called_once_with(fit_data)
-        model_instance_mock.assert_not_called()
-        model_instance_mock.cdf.assert_called_once_with(call_data)
-
-    @patch('copulas.univariate.base.scipy.stats', autospec=True)
-    def test_percent_point(self, scipy_mock):
-        """percent_point calls to the mapped method of model."""
-        # Setup
-        class ScipyWrapperSubclass(ScipyWrapper):
-            model_class = 'mock_model'
-            probability_density = None
-            cumulative_distribution = None
-            percent_point = 'ppf'
-            sample = None
-
-        model_instance_mock = MagicMock(spec=['ppf'])
-        model_instance_mock.ppf.return_value = 'ppf value'
-        model_class_mock = MagicMock()
-        model_class_mock.return_value = model_instance_mock
-        scipy_mock.mock_model = model_class_mock
-
-        fit_data = np.array(range(5))
-        instance = ScipyWrapperSubclass()
-        instance.fit(fit_data)
-
-        call_data = np.array([0.0])
-        expected_result = 'ppf value'
-
-        # Run
-        result = instance.percent_point(call_data)
-
-        # Check
-        assert result == expected_result
-
-        scipy_mock.assert_not_called()
-        model_class_mock.assert_called_once_with(fit_data)
-        model_instance_mock.assert_not_called()
-        model_instance_mock.ppf.assert_called_once_with(call_data)
-
-    @patch('copulas.univariate.base.scipy.stats', autospec=True)
-    def test_sample(self, scipy_mock):
-        """sample calls to the mapped method of model."""
-        # Setup
-        class ScipyWrapperSubclass(ScipyWrapper):
-            model_class = 'mock_model'
-            probability_density = None
-            cumulative_distribution = None
-            percent_point = None
-            sample = 'sample'
-
-        model_instance_mock = MagicMock(spec=['sample'])
-        model_instance_mock.sample.return_value = 'samples'
-        model_class_mock = MagicMock()
-        model_class_mock.return_value = model_instance_mock
-        scipy_mock.mock_model = model_class_mock
-
-        fit_data = np.array(range(5))
-        instance = ScipyWrapperSubclass()
-        instance.fit(fit_data)
-
-        call_data = np.array([0.0])
-        expected_result = 'samples'
-
-        # Run
-        result = instance.sample(call_data)
-
-        # Check
-        assert result == expected_result
-
-        scipy_mock.assert_not_called()
-        model_class_mock.assert_called_once_with(fit_data)
-        model_instance_mock.assert_not_called()
-        model_instance_mock.sample.assert_called_once_with(call_data)
-
-    def test_from_dict(self):
-        """_from_dict will raise NotImpementedError."""
-        # Run / Check
-        with self.assertRaises(NotImplementedError):
-            ScipyWrapper.from_dict({})

--- a/tests/unit/univariate/test_beta.py
+++ b/tests/unit/univariate/test_beta.py
@@ -8,47 +8,43 @@ from copulas.univariate import BetaUnivariate
 
 class TestBetaUnivariate(TestCase):
 
-    def test___init__(self):
-        """On init, default values are set on instance."""
-        copula = BetaUnivariate()
-        assert copula.a is None
-        assert copula.b is None
-        assert copula.loc is None
-        assert copula.scale is None
+    def test__fit_constant(self):
+        distribution = BetaUnivariate()
 
-    def test_fit(self):
-        """On fit, stats from fit data are set in the model."""
+        distribution._fit_constant(np.array([1, 1, 1, 1]))
 
-        # Generate data with known parameters
-        np.random.seed(42)
-        a, b, loc, scale = 1.0, 1.0, 10.0, 11.0
-        data = beta.rvs(a, b, loc, scale, size=100000)
+        assert distribution._params == {
+            'a': 1,
+            'b': 1,
+            'loc': 1,
+            'scale': 0
+        }
 
-        # Fit the model and check parameters
-        copula = BetaUnivariate()
-        copula.fit(data)
-        self.assertAlmostEqual(copula.a, a, places=1)
-        self.assertAlmostEqual(copula.b, b, places=1)
-        self.assertAlmostEqual(copula.loc, loc, places=1)
-        self.assertAlmostEqual(copula.scale, scale, places=1)
+    def test__fit(self):
+        distribution = BetaUnivariate()
 
-    def test_test_fit_equal_values(self):
-        """If it's fit with constant data, contant_value is set."""
-        instance = BetaUnivariate()
-        instance.fit(np.array([5, 5, 5, 5, 5, 5]))
-        assert instance.a is None
-        assert instance.b is None
-        assert instance.constant_value == 5
+        data = beta.rvs(size=10000, a=1, b=1, loc=1, scale=1)
+        distribution._fit(data)
 
-    def test_valid_serialization_unfit_model(self):
-        """For a unfitted model to_dict and from_dict are opposites."""
-        instance = BetaUnivariate()
-        result = BetaUnivariate.from_dict(instance.to_dict())
-        assert instance.to_dict() == result.to_dict()
+        expected = {
+            'loc': 1,
+            'scale': 1,
+            'a': 1,
+            'b': 1
+        }
+        for key, value in distribution._params.items():
+            np.testing.assert_allclose(value, expected[key], atol=0.1)
 
-    def test_valid_serialization_fit_model(self):
-        """For a fitted model to_dict and from_dict are opposites."""
-        instance = BetaUnivariate()
-        instance.fit(np.array([1, 2, 3, 2, 1]))
-        result = BetaUnivariate.from_dict(instance.to_dict())
-        assert instance.to_dict() == result.to_dict()
+    def test__is_constant_true(self):
+        distribution = BetaUnivariate()
+
+        distribution.fit(np.array([1, 1, 1, 1]))
+
+        assert distribution._is_constant()
+
+    def test__is_constant_false(self):
+        distribution = BetaUnivariate()
+
+        distribution.fit(np.array([1, 2, 3, 4]))
+
+        assert not distribution._is_constant()

--- a/tests/unit/univariate/test_gaussian.py
+++ b/tests/unit/univariate/test_gaussian.py
@@ -1,268 +1,44 @@
 from unittest import TestCase
-from unittest.mock import patch
 
 import numpy as np
-import pandas as pd
+from scipy.stats import norm
 
 from copulas.univariate.gaussian import GaussianUnivariate
-from tests import compare_nested_iterables
 
 
 class TestGaussianUnivariate(TestCase):
 
-    def test___init__(self):
-        """On init, default values are set on instance."""
+    def test__fit_constant(self):
+        distribution = GaussianUnivariate()
 
-        # Setup / Run
-        copula = GaussianUnivariate()
+        distribution._fit_constant(np.array([1, 1, 1, 1]))
 
-        # Check
-        assert not copula.name
-        assert copula.mean is None
-        assert copula.std is None
-        assert copula.constant_value is None
-
-    def test___str__(self):
-        """str returns details about the model."""
-
-        # Setup
-        copula = GaussianUnivariate()
-        expected_result = '\n'.join([
-            'Distribution Type: Gaussian',
-            'Variable name: None',
-            'Mean: None',
-            'Standard deviation: None'
-        ])
-
-        # Run
-        result = copula.__str__()
-
-        # Check
-        assert result == expected_result
-
-    def test_fit(self):
-        """On fit, stats from fit data are set in the model."""
-
-        # Setup
-        copula = GaussianUnivariate()
-        column = pd.Series([0, 1, 2, 3, 4, 5], name='column')
-
-        # Run
-        copula.fit(column)
-
-        # Check
-        assert copula.mean == 2.5
-        assert copula.std == 1.707825127659933
-        assert copula.name == 'column'
-        assert copula.fitted is True
-
-    def test_test_fit_equal_values(self):
-        """If it's fit with constant data, contant_value is set."""
-
-        # Setup
-        instance = GaussianUnivariate()
-        column = np.array([5, 5, 5, 5, 5, 5])
-
-        # Run
-        instance.fit(column)
-
-        # Check
-        assert instance.mean is None
-        assert instance.std is None
-        assert instance.constant_value == 5
-
-    def test_get_probability_density(self):
-        """Probability_density returns the normal probability distribution for the given values."""
-
-        # Setup
-        copula = GaussianUnivariate()
-        column = np.array([-1, 0, 1])
-        copula.fit(column)
-        expected_result = 0.48860251190292
-
-        # Run
-        result = copula.probability_density(0)
-
-        # Check
-        assert result == expected_result
-
-    def test_cumulative_distribution(self):
-        """Cumulative_density returns the cumulative distribution value for a point."""
-
-        # Setup
-        copula = GaussianUnivariate()
-        column = np.array([-1, 0, 1])
-        copula.fit(column)
-        x = pd.Series([0])
-        expected_result = [0.5]
-
-        # Run
-        result = copula.cumulative_distribution(x)
-
-        # Check
-        assert (result == expected_result).all()
-
-    def test_cumulative_distribution_constant(self):
-        """cumulative_distribution can be computed for constant distribution."""
-        # Setup
-        instance = GaussianUnivariate()
-        instance.constant_value = 3
-        instance._replace_constant_methods()
-        instance.fitted = True
-
-        X = np.array([1, 2, 3, 4, 5])
-        expected_result = np.array([0, 0, 1, 1, 1])
-
-        # Run
-        result = instance.cumulative_distribution(X)
-
-        # Check
-        compare_nested_iterables(result, expected_result)
-
-    def test_percent_point(self):
-        """Percent_point returns the original point from the cumulative probability value."""
-
-        # Setup
-        copula = GaussianUnivariate()
-        column = np.array([-1, 0, 1])
-        copula.fit(column)
-        x = 0.5
-        expected_result = 0
-
-        # Run
-        result = copula.percent_point(x)
-
-        # Check
-        assert (result == expected_result).all()
-
-    def test_percent_point_reverse_cumulative_distribution(self):
-        """Combined cumulative_distribution and percent_point is the identity function."""
-
-        # Setup
-        copula = GaussianUnivariate()
-        column = np.array([-1, 0, 1])
-        copula.fit(column)
-        initial_value = np.array([0, 0.1, 0.2, 0.3, 0.4, 0.5])
-
-        # Run
-        result_a = copula.percent_point(copula.cumulative_distribution(initial_value))
-        result_b = copula.cumulative_distribution(copula.percent_point(initial_value))
-
-        # Check
-        assert (initial_value - result_a < 10E-5).all()
-        assert (initial_value - result_b < 10E-5).all()
-
-    @patch('copulas.univariate.gaussian.np.random.normal')
-    def test_sample(self, random_mock):
-        """After fitting, GaussianUnivariate is able to sample new data."""
-        # Setup
-        instance = GaussianUnivariate()
-        column = np.array([-1, 0, 1])
-        instance.fit(column)
-
-        expected_result = np.array([1, 2, 3, 4, 5])
-        random_mock.return_value = expected_result
-
-        # Run
-        result = instance.sample(5)
-
-        # Check
-        compare_nested_iterables(result, expected_result)
-
-        assert instance.mean == 0.0
-        assert instance.std == 0.816496580927726
-        random_mock.assert_called_once_with(0.0, 0.816496580927726, 5)
-
-    def test_sample_random_state(self):
-        """When random state is set, samples are the same."""
-        # Setup
-        instance = GaussianUnivariate(random_seed=0)
-        X = np.array([1, 2, 3, 4, 5])
-        instance.fit(X)
-
-        expected_result = np.array([5.494746752403546, 3.565907751154284, 4.384144531132039])
-
-        # Run
-        result = instance.sample(3)
-
-        # Check
-        assert (result == expected_result).all()
-
-    def test_sample_constant(self):
-        """samples can be generated for constant distribution."""
-        # Setup
-        instance = GaussianUnivariate()
-        instance.constant_value = 3
-        instance._replace_constant_methods()
-        instance.fitted = True
-
-        expected_result = np.array([3, 3, 3, 3, 3])
-
-        # Run
-        result = instance.sample(5)
-
-        # Check
-        compare_nested_iterables(result, expected_result)
-
-    def test_to_dict(self):
-        """To_dict returns the defining parameters of a distribution in a dict."""
-        # Setup
-        copula = GaussianUnivariate()
-        column = np.array([0, 1, 2, 3, 4, 5])
-        copula.fit(column)
-        expected_result = {
-            'type': 'copulas.univariate.gaussian.GaussianUnivariate',
-            'mean': 2.5,
-            'std': 1.707825127659933,
-            'fitted': True,
+        assert distribution._params == {
+            'loc': 1,
+            'scale': 0
         }
 
-        # Run
-        result = copula.to_dict()
+    def test__fit(self):
+        distribution = GaussianUnivariate()
 
-        # Check
-        assert result == expected_result
+        data = norm.rvs(size=1000, loc=1, scale=1)
+        distribution._fit(data)
 
-    def test_from_dict(self):
-        """From_dict sets the values of a dictionary as attributes of the instance."""
-        # Setup
-        parameters = {
-            'mean': 2.5,
-            'std': 1.707825127659933,
-            'fitted': True,
+        assert distribution._params == {
+            'loc': np.mean(data),
+            'scale': np.std(data),
         }
 
-        # Run
-        copula = GaussianUnivariate.from_dict(parameters)
+    def test__is_constant_true(self):
+        distribution = GaussianUnivariate()
 
-        # Check
-        assert copula.mean == 2.5
-        assert copula.std == 1.707825127659933
-        assert copula.fitted
+        distribution.fit(np.array([1, 1, 1, 1]))
 
-        copula.sample(10)
+        assert distribution._is_constant()
 
-    def test_valid_serialization_unfit_model(self):
-        """For a unfitted model to_dict and from_dict are opposites."""
-        # Setup
-        instance = GaussianUnivariate()
+    def test__is_constant_false(self):
+        distribution = GaussianUnivariate()
 
-        # Run
-        result = GaussianUnivariate.from_dict(instance.to_dict())
+        distribution.fit(np.array([1, 2, 3, 4]))
 
-        # Check
-        assert instance.to_dict() == result.to_dict()
-
-    def test_valid_serialization_fit_model(self):
-        """For a fitted model to_dict and from_dict are opposites."""
-        # Setup
-        instance = GaussianUnivariate()
-        instance.fitted = True
-        instance.std = 1
-        instance.mean = 5
-
-        # Run
-        result = GaussianUnivariate.from_dict(instance.to_dict())
-
-        # Check
-        assert instance.to_dict() == result.to_dict()
+        assert not distribution._is_constant()

--- a/tests/unit/univariate/test_truncated_gaussian.py
+++ b/tests/unit/univariate/test_truncated_gaussian.py
@@ -1,128 +1,50 @@
 from unittest import TestCase
 
+import numpy as np
 from scipy.stats import truncnorm
-from scipy.stats.distributions import rv_frozen
 
 from copulas.univariate.truncated_gaussian import TruncatedGaussian
 
 
 class TestTruncatedGaussian(TestCase):
 
-    def test_init(self):
-        """On init, there are no errors and attributes are set as expected."""
-        # Run / Setup
-        instance = TruncatedGaussian()
+    def test__fit_constant(self):
+        distribution = TruncatedGaussian()
 
-        # Check
-        assert instance.model_class == 'truncnorm'
-        assert instance.unfittable_model is True
-        assert instance.probability_density == 'pdf'
-        assert instance.cumulative_distribution == 'cdf'
-        assert instance.percent_point == 'ppf'
-        assert instance.sample == 'rvs'
-        assert instance.model is None
-        assert instance.fitted is False
-        assert instance.constant_value is None
+        distribution._fit_constant(np.array([1, 1, 1, 1]))
 
-    def test_fit(self):
-        """On fit, the attribute model is set with an instance of scipy.stats.truncnorm."""
-        # Setup
-        instance = TruncatedGaussian()
-
-        # Generate data from a truncated gaussian
-        loc, scale = 2.0, 1.0
-        min_value, max_value = -1.0, 4.0
-        a = (min_value - loc) / scale
-        b = (max_value - loc) / scale
-        data = truncnorm.rvs(a=a, b=b, loc=loc, scale=scale, size=1000000, random_state=42)
-
-        # Run
-        instance.fit(data)
-
-        # Check
-        assert isinstance(instance.model, rv_frozen)
-        self.assertAlmostEqual(min_value, instance.min, places=2)
-        self.assertAlmostEqual(max_value, instance.max, places=2)
-        self.assertAlmostEqual(loc, instance.mean, places=2)
-        self.assertAlmostEqual(scale, instance.std, places=2)
-
-    def test_from_dict_unfitted(self):
-        """from_dict creates a new instance from a dict of params."""
-        # Setup
-        parameters = {
-            'type': 'copulas.univariate.truncnorm.TruncatedGaussian',
-            'fitted': False,
+        assert distribution._params == {
+            'a': 1,
+            'b': 1,
+            'loc': 1,
+            'scale': 0
         }
 
-        # Run
-        instance = TruncatedGaussian.from_dict(parameters)
+    def test__fit(self):
+        distribution = TruncatedGaussian()
 
-        # Check
-        assert instance.fitted is False
-        assert instance.constant_value is None
-        assert instance.model is None
+        data = truncnorm.rvs(size=10000, a=0, b=3, loc=3, scale=1)
+        distribution._fit(data)
 
-    def test_from_dict_fitted(self):
-        """from_dict creates a new instance from a dict of params."""
-        # Setup
-        parameters = {
-            'type': 'copulas.univariate.truncnorm.TruncatedGaussian',
-            'fitted': True,
-            'min': -10,
-            'max': 10,
-            'std': 1,
-            'mean': 1,
+        expected = {
+            'loc': 3,
+            'scale': 1,
+            'a': 0,
+            'b': 3
         }
+        for key, value in distribution._params.items():
+            np.testing.assert_allclose(value, expected[key], atol=0.1)
 
-        # Run
-        instance = TruncatedGaussian.from_dict(parameters)
+    def test__is_constant_true(self):
+        distribution = TruncatedGaussian()
 
-        # Check
-        assert instance.fitted is True
-        assert isinstance(instance.model, rv_frozen)
-        assert instance.constant_value is None
-        assert instance.min == -10
-        assert instance.max == 10
-        assert instance.std == 1
-        assert instance.mean == 1
+        distribution.fit(np.array([1, 1, 1, 1]))
 
-    def test_from_dict_constant(self):
-        """from_dict creates a new instance from a dict of params."""
-        # Setup
-        parameters = {
-            'type': 'copulas.univariate.truncnorm.TruncatedGaussian',
-            'fitted': True,
-            'min': 10,
-            'max': 10,
-            'std': 0,
-            'mean': 10,
-        }
+        assert distribution._is_constant()
 
-        # Run
-        instance = TruncatedGaussian.from_dict(parameters)
+    def test__is_constant_false(self):
+        distribution = TruncatedGaussian()
 
-        # Check
-        assert instance.fitted is True
-        assert instance.constant_value == 10
+        distribution.fit(np.array([1, 2, 3, 4]))
 
-    def test__fit_params(self):
-        """_fit_params returns a dict with the params of the scipy model."""
-        # Setup
-        instance = TruncatedGaussian()
-        instance.min = 0
-        instance.max = 4
-        instance.std = 1
-        instance.mean = 2
-
-        expected_result = {
-            'min': 0,
-            'max': 4,
-            'std': 1,
-            'mean': 2,
-        }
-
-        # Run
-        result = instance._fit_params()
-
-        # Check
-        assert result == expected_result
+        assert not distribution._is_constant()


### PR DESCRIPTION
Simplify Univariates implementation by replacing ScipyWrapper with a ScipyModel class which provides a simpler integration with Scipy that requires less methods to be implemented by subclasses,

Also curate returned parameters to provide a 1-to-1 mapping with scipy's underlying models and improve how the constant values are encoded within the stored parameters.