### PR TITLE
Fixes readme mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you want to install from source or contribute to the project please read the
 **Copulas** can also be installed using [conda](https://docs.conda.io/en/latest/):
 
 ```bash
-conda install -c sdv-dev copulas
+conda install -c sdv-dev -c conda-forge copulas
 ```
 
 This will pull and install the latest stable release from [Anaconda](https://anaconda.org/).


### PR DESCRIPTION
Adds conda-forge to the list of channels needed to install Copulas through conda.