### PR TITLE
Vectorize cdf, ppf

### DIFF
--- a/copulas/optimize/__init__.py
+++ b/copulas/optimize/__init__.py
@@ -5,7 +5,7 @@ def bisect(f, xmin, xmax, tol=1e-8, maxiter=50):
     """Bisection method for finding roots.
 
     This method implements a simple vectorized routine for identifying
-    the root (of a monotonically increasing function) given a bracketing 
+    the root (of a monotonically increasing function) given a bracketing
     interval.
 
     Arguments:

--- a/copulas/optimize/__init__.py
+++ b/copulas/optimize/__init__.py
@@ -1,0 +1,150 @@
+import numpy as np
+
+
+def bisect(f, xmin, xmax, tol=1e-8, maxiter=50):
+    """Bisection method for finding roots.
+
+    This method implements a simple vectorized routine for identifying
+    the root (of a monotonically increasing function) given a bracketing 
+    interval.
+
+    Arguments:
+        f (Callable):
+            A function which takes as input a vector x and returns a
+            vector with the same number of dimensions.
+        xmin (np.ndarray):
+            The minimum value for x such that f(x) <= 0.
+        xmax (np.ndarray):
+            The maximum value for x such that f(x) >= 0.
+
+    Returns:
+        numpy.ndarray:
+            The value of x such that f(x) is close to 0.
+    """
+    assert (f(xmin) <= 0.0).all()
+    assert (f(xmax) >= 0.0).all()
+
+    for _ in range(maxiter):
+        guess = (xmin + xmax) / 2.0
+        fguess = f(guess)
+        xmin[fguess <= 0] = guess[fguess <= 0]
+        xmax[fguess >= 0] = guess[fguess >= 0]
+        if (xmax - xmin).max() < tol:
+            break
+
+    return (xmin + xmax) / 2.0
+
+
+def chandrupatla(f, xmin, xmax, eps_m=None, eps_a=None, maxiter=50):
+    """Chandrupatla's algorithm.
+
+    This is adapted from [1] which implements Chandrupatla's algorithm [2]
+    which starts from a bracketing interval and, conditionally, swaps between
+    bisection and inverse quadratic interpolation.
+
+    [1] https://github.com/scipy/scipy/issues/7242#issuecomment-290548427
+    [2] https://books.google.com/books?id=cC-8BAAAQBAJ&pg=PA95
+
+    Arguments:
+        f (Callable):
+            A function which takes as input a vector x and returns a
+            vector with the same number of dimensions.
+        xmin (np.ndarray):
+            The minimum value for x such that f(x) <= 0.
+        xmax (np.ndarray):
+            The maximum value for x such that f(x) >= 0.
+
+    Returns:
+        numpy.ndarray:
+            The value of x such that f(x) is close to 0.
+    """
+    # Initialization
+    a = xmax
+    b = xmin
+    fa = f(a)
+    fb = f(b)
+
+    # Make sure we know the size of the result
+    shape = np.shape(fa)
+    assert shape == np.shape(fb)
+
+    fc = fa
+    c = a
+
+    # Make sure we are bracketing a root in each case
+    assert (np.sign(fa) * np.sign(fb) <= 0).all()
+    t = 0.5
+    # Initialize an array of False,
+    # determines whether we should do inverse quadratic interpolation
+    iqi = np.zeros(shape, dtype=bool)
+
+    # jms: some guesses for default values of the eps_m and eps_a settings
+    # based on machine precision... not sure exactly what to do here
+    eps = np.finfo(float).eps
+    if eps_m is None:
+        eps_m = eps
+    if eps_a is None:
+        eps_a = 2 * eps
+
+    iterations = 0
+    terminate = False
+
+    while maxiter > 0:
+        maxiter -= 1
+        # use t to linearly interpolate between a and b,
+        # and evaluate this function as our newest estimate xt
+        xt = np.clip(a + t * (b - a), xmin, xmax)
+        ft = f(xt)
+
+        # update our history of the last few points so that
+        # - a is the newest estimate (we're going to update it from xt)
+        # - c and b get the preceding two estimates
+        # - a and b maintain opposite signs for f(a) and f(b)
+        samesign = np.sign(ft) == np.sign(fa)
+        c = np.choose(samesign, [b, a])
+        b = np.choose(samesign, [a, b])
+        fc = np.choose(samesign, [fb, fa])
+        fb = np.choose(samesign, [fa, fb])
+        a = xt
+        fa = ft
+
+        # set xm so that f(xm) is the minimum magnitude of f(a) and f(b)
+        fa_is_smaller = np.abs(fa) < np.abs(fb)
+        xm = np.choose(fa_is_smaller, [b, a])
+        fm = np.choose(fa_is_smaller, [fb, fa])
+
+        tol = 2 * eps_m * np.abs(xm) + eps_a
+        tlim = tol / np.abs(b - c)
+        terminate = np.logical_or(terminate, np.logical_or(fm == 0, tlim > 0.5))
+
+        if np.all(terminate):
+            break
+        iterations += 1 - terminate
+
+        # Figure out values xi and phi
+        # to determine which method we should use next
+        xi = (a - b) / (c - b)
+        phi = (fa - fb) / (fc - fb)
+        iqi = np.logical_and(phi**2 < xi, (1 - phi)**2 < 1 - xi)
+
+        if not shape:
+            # scalar case
+            if iqi:
+                # inverse quadratic interpolation
+                t = fa / (fb - fa) * fc / (fb - fc) + (c - a) / \
+                    (b - a) * fa / (fc - fa) * fb / (fc - fb)
+            else:
+                # bisection
+                t = 0.5
+        else:
+            # array case
+            t = np.full(shape, 0.5)
+            a2, b2, c2, fa2, fb2, fc2 = a[iqi], b[iqi], c[iqi], fa[iqi], fb[iqi], fc[iqi]
+            t[iqi] = fa2 / (fb2 - fa2) * fc2 / (fb2 - fc2) + (c2 - a2) / \
+                (b2 - a2) * fa2 / (fc2 - fa2) * fb2 / (fc2 - fb2)
+
+        # limit to the range (tlim, 1-tlim)
+        t = np.minimum(1 - tlim, np.maximum(tlim, t))
+
+    # done!
+    return xm

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -9,7 +9,7 @@ from copulas import EPSILON, scalarize, store_args
 from copulas.univariate.base import BoundedType, ParametricType, ScipyModel
 
 
-def _bisect(f, xmin, xmax, tol=1e-6, verbose=False):
+def _bisect(f, xmin, xmax, tol=1e-8, maxiter=50):
     a, b = xmin, xmax
 
     fa = f(a)
@@ -17,11 +17,13 @@ def _bisect(f, xmin, xmax, tol=1e-6, verbose=False):
     assert (fa <= 0.0).all()
     assert (fb >= 0.0).all()
 
-    while (b - a).max() > tol:
+    for _ in range(maxiter):
         c = (a + b) / 2.0  # proposal
         fc = f(c)
         a[fc <= 0] = c[fc <= 0]
         b[fc >= 0] = c[fc >= 0]
+        if (b - a).max() < tol:
+            break
 
     return (a + b) / 2.0
 

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -1,12 +1,140 @@
 from functools import partial
 
 import numpy as np
-from scipy.optimize import brentq, newton
+from scipy.optimize import brentq
 from scipy.special import ndtr
 from scipy.stats import gaussian_kde
 
 from copulas import EPSILON, scalarize, store_args
 from copulas.univariate.base import BoundedType, ParametricType, ScipyModel
+
+
+def _bisect(f, xmin, xmax, tol=1e-6, verbose=False):
+    a, b = xmin, xmax
+
+    fa = f(a)
+    fb = f(b)
+    assert (fa <= 0.0).all()
+    assert (fb >= 0.0).all()
+
+    while (b - a).max() > tol:
+        c = (a + b) / 2.0  # proposal
+        fc = f(c)
+        a[fc <= 0] = c[fc <= 0]
+        b[fc >= 0] = c[fc >= 0]
+
+    return (a + b) / 2.0
+
+
+def _chandrupatla(f, xmin, xmax, verbose=False,
+                  eps_m=None, eps_a=None,
+                  maxiter=50, return_iter=False, args=(),):
+    """
+    This is adapted from [1] which implements Chandrupatla's algorithm [2]
+    which starts from a bracketing interval and, conditionally, swaps between
+    bisection and inverse quadratic interpolation.
+
+    [1] https://github.com/scipy/scipy/issues/7242#issuecomment-290548427
+    [2] https://books.google.com/books?id=cC-8BAAAQBAJ&pg=PA95
+    """
+    # Initialization
+    a = xmax
+    b = xmin
+    fa = f(a, *args)
+    fb = f(b, *args)
+
+    # Make sure we know the size of the result
+    shape = np.shape(fa)
+    assert shape == np.shape(fb)
+
+    fc = fa
+    c = a
+
+    # Make sure we are bracketing a root in each case
+    assert (np.sign(fa) * np.sign(fb) <= 0).all()
+    t = 0.5
+    # Initialize an array of False,
+    # determines whether we should do inverse quadratic interpolation
+    iqi = np.zeros(shape, dtype=bool)
+
+    # jms: some guesses for default values of the eps_m and eps_a settings
+    # based on machine precision... not sure exactly what to do here
+    eps = np.finfo(float).eps
+    if eps_m is None:
+        eps_m = eps
+    if eps_a is None:
+        eps_a = 2 * eps
+
+    iterations = 0
+    terminate = False
+
+    while maxiter > 0:
+        maxiter -= 1
+        # use t to linearly interpolate between a and b,
+        # and evaluate this function as our newest estimate xt
+        xt = np.clip(a + t * (b - a), xmin, xmax)
+        ft = f(xt, *args)
+        if verbose:
+            output = 'IQI? %s\nt=%s\nxt=%s\nft=%s\na=%s\nb=%s\nc=%s' % (iqi, t, xt, ft, a, b, c)
+            print(output)
+        # update our history of the last few points so that
+        # - a is the newest estimate (we're going to update it from xt)
+        # - c and b get the preceding two estimates
+        # - a and b maintain opposite signs for f(a) and f(b)
+        samesign = np.sign(ft) == np.sign(fa)
+        c = np.choose(samesign, [b, a])
+        b = np.choose(samesign, [a, b])
+        fc = np.choose(samesign, [fb, fa])
+        fb = np.choose(samesign, [fa, fb])
+        a = xt
+        fa = ft
+
+        # set xm so that f(xm) is the minimum magnitude of f(a) and f(b)
+        fa_is_smaller = np.abs(fa) < np.abs(fb)
+        xm = np.choose(fa_is_smaller, [b, a])
+        fm = np.choose(fa_is_smaller, [fb, fa])
+
+        tol = 2 * eps_m * np.abs(xm) + eps_a
+        tlim = tol / np.abs(b - c)
+        terminate = np.logical_or(terminate, np.logical_or(fm == 0, tlim > 0.5))
+        if verbose:
+            output = "fm=%s\ntlim=%s\nterm=%s" % (fm, tlim, terminate)
+            print(output)
+
+        if np.all(terminate):
+            break
+        iterations += 1 - terminate
+
+        # Figure out values xi and phi
+        # to determine which method we should use next
+        xi = (a - b) / (c - b)
+        phi = (fa - fb) / (fc - fb)
+        iqi = np.logical_and(phi**2 < xi, (1 - phi)**2 < 1 - xi)
+
+        if not shape:
+            # scalar case
+            if iqi:
+                # inverse quadratic interpolation
+                t = fa / (fb - fa) * fc / (fb - fc) + (c - a) / \
+                    (b - a) * fa / (fc - fa) * fb / (fc - fb)
+            else:
+                # bisection
+                t = 0.5
+        else:
+            # array case
+            t = np.full(shape, 0.5)
+            a2, b2, c2, fa2, fb2, fc2 = a[iqi], b[iqi], c[iqi], fa[iqi], fb[iqi], fc[iqi]
+            t[iqi] = fa2 / (fb2 - fa2) * fc2 / (fb2 - fc2) + (c2 - a2) / \
+                (b2 - a2) * fa2 / (fc2 - fa2) * fb2 / (fc2 - fb2)
+
+        # limit to the range (tlim, 1-tlim)
+        t = np.minimum(1 - tlim, np.maximum(tlim, t))
+
+    # done!
+    if return_iter:
+        return xm, iterations
+    else:
+        return xm
 
 
 class GaussianKDE(ScipyModel):
@@ -99,11 +227,11 @@ class GaussianKDE(ScipyModel):
             NotFittedError:
                 if the model is not fitted.
         """
-        X = np.array(X)
         self.check_fit()
+        X = np.array(X)
         stdev = np.sqrt(self._model.covariance[0, 0])
         lower = ndtr((self._get_bounds()[0] - self._model.dataset) / stdev)[0]
-        uppers = ndtr((X[:,  None] - self._model.dataset) / stdev)
+        uppers = ndtr((X[:, None] - self._model.dataset) / stdev)
         return (uppers - lower).dot(self._model.weights)
 
     def _brentq_cdf(self, value):
@@ -134,7 +262,7 @@ class GaussianKDE(ScipyModel):
 
         return f
 
-    def percent_point(self, U):
+    def percent_point_slow(self, U):
         """Compute the inverse cumulative distribution value for each point in U.
 
         Arguments:
@@ -158,7 +286,7 @@ class GaussianKDE(ScipyModel):
 
             if len(U.shape) == 2:
                 return np.fromiter(
-                    (self.percent_point(u[0]) for u in U),
+                    (self.percent_point_slow(u[0]) for u in U),
                     np.dtype('float64')
                 )
 
@@ -181,7 +309,7 @@ class GaussianKDE(ScipyModel):
 
         return X
 
-    def percent_point_fast(self, U):
+    def percent_point(self, U, method="bisect"):
         """Compute the inverse cumulative distribution value for each point in U.
 
         Arguments:
@@ -199,24 +327,31 @@ class GaussianKDE(ScipyModel):
         """
         self.check_fit()
 
-        assert len(U.shape) == 1
+        if len(U.shape) > 1:
+            raise ValueError("Expected 1d array, got %s." % (U, ))
 
         if np.any(U > 1.0) or np.any(U < 0.0):
             raise ValueError("Expected values in range [0.0, 1.0].")
 
         is_one = U >= 1.0 - EPSILON
         is_zero = U <= EPSILON
-        is_valid = np.logical_not(np.logical_or(is_zero, is_one))
+        is_valid = ~(is_zero | is_one)
 
         lower, upper = self._get_bounds()
 
         def _f(X):
-            return U[is_valid] - self.cumulative_distribution(X)
+            return self.cumulative_distribution(X) - U[is_valid]
 
         X = np.zeros(U.shape)
         X[is_one] = float("inf")
         X[is_zero] = float("-inf")
-        X[is_valid] = newton(_f, np.zeros(U[is_valid].shape) + (lower + upper) / 2.0)
+        if is_valid.any():
+            lower = np.full(U[is_valid].shape, lower)
+            upper = np.full(U[is_valid].shape, upper)
+            if method == "bisect":
+                X[is_valid] = _bisect(_f, lower, upper)
+            else:
+                X[is_valid] = _chandrupatla(_f, lower, upper)
 
         return X
 

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -1,11 +1,9 @@
-from functools import partial
 
 import numpy as np
-from scipy.optimize import brentq
 from scipy.special import ndtr
 from scipy.stats import gaussian_kde
 
-from copulas import EPSILON, scalarize, store_args
+from copulas import EPSILON, store_args
 from copulas.optimize import bisect, chandrupatla
 from copulas.univariate.base import BoundedType, ParametricType, ScipyModel
 

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -103,7 +103,7 @@ class GaussianKDE(ScipyModel):
         self.check_fit()
         stdev = np.sqrt(self._model.covariance[0, 0])
         lower = ndtr((self._get_bounds()[0] - self._model.dataset) / stdev)[0]
-        uppers = ndtr((X[:,None] - self._model.dataset) / stdev)
+        uppers = ndtr((X[:,  None] - self._model.dataset) / stdev)
         return (uppers - lower).dot(self._model.weights)
 
     def _brentq_cdf(self, value):
@@ -216,7 +216,7 @@ class GaussianKDE(ScipyModel):
         X = np.zeros(U.shape)
         X[is_one] = float("inf")
         X[is_zero] = float("-inf")
-        X[is_valid] = newton(_f, np.zeros(U[is_valid].shape) + (lower+upper)/2.0)
+        X[is_valid] = newton(_f, np.zeros(U[is_valid].shape) + (lower + upper) / 2.0)
 
         return X
 

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -6,137 +6,8 @@ from scipy.special import ndtr
 from scipy.stats import gaussian_kde
 
 from copulas import EPSILON, scalarize, store_args
+from copulas.optimize import bisect, chandrupatla
 from copulas.univariate.base import BoundedType, ParametricType, ScipyModel
-
-
-def _bisect(f, xmin, xmax, tol=1e-8, maxiter=50):
-    a, b = xmin, xmax
-
-    fa = f(a)
-    fb = f(b)
-    assert (fa <= 0.0).all()
-    assert (fb >= 0.0).all()
-
-    for _ in range(maxiter):
-        c = (a + b) / 2.0  # proposal
-        fc = f(c)
-        a[fc <= 0] = c[fc <= 0]
-        b[fc >= 0] = c[fc >= 0]
-        if (b - a).max() < tol:
-            break
-
-    return (a + b) / 2.0
-
-
-def _chandrupatla(f, xmin, xmax, verbose=False,
-                  eps_m=None, eps_a=None,
-                  maxiter=50, return_iter=False, args=(),):
-    """
-    This is adapted from [1] which implements Chandrupatla's algorithm [2]
-    which starts from a bracketing interval and, conditionally, swaps between
-    bisection and inverse quadratic interpolation.
-
-    [1] https://github.com/scipy/scipy/issues/7242#issuecomment-290548427
-    [2] https://books.google.com/books?id=cC-8BAAAQBAJ&pg=PA95
-    """
-    # Initialization
-    a = xmax
-    b = xmin
-    fa = f(a, *args)
-    fb = f(b, *args)
-
-    # Make sure we know the size of the result
-    shape = np.shape(fa)
-    assert shape == np.shape(fb)
-
-    fc = fa
-    c = a
-
-    # Make sure we are bracketing a root in each case
-    assert (np.sign(fa) * np.sign(fb) <= 0).all()
-    t = 0.5
-    # Initialize an array of False,
-    # determines whether we should do inverse quadratic interpolation
-    iqi = np.zeros(shape, dtype=bool)
-
-    # jms: some guesses for default values of the eps_m and eps_a settings
-    # based on machine precision... not sure exactly what to do here
-    eps = np.finfo(float).eps
-    if eps_m is None:
-        eps_m = eps
-    if eps_a is None:
-        eps_a = 2 * eps
-
-    iterations = 0
-    terminate = False
-
-    while maxiter > 0:
-        maxiter -= 1
-        # use t to linearly interpolate between a and b,
-        # and evaluate this function as our newest estimate xt
-        xt = np.clip(a + t * (b - a), xmin, xmax)
-        ft = f(xt, *args)
-        if verbose:
-            output = 'IQI? %s\nt=%s\nxt=%s\nft=%s\na=%s\nb=%s\nc=%s' % (iqi, t, xt, ft, a, b, c)
-            print(output)
-        # update our history of the last few points so that
-        # - a is the newest estimate (we're going to update it from xt)
-        # - c and b get the preceding two estimates
-        # - a and b maintain opposite signs for f(a) and f(b)
-        samesign = np.sign(ft) == np.sign(fa)
-        c = np.choose(samesign, [b, a])
-        b = np.choose(samesign, [a, b])
-        fc = np.choose(samesign, [fb, fa])
-        fb = np.choose(samesign, [fa, fb])
-        a = xt
-        fa = ft
-
-        # set xm so that f(xm) is the minimum magnitude of f(a) and f(b)
-        fa_is_smaller = np.abs(fa) < np.abs(fb)
-        xm = np.choose(fa_is_smaller, [b, a])
-        fm = np.choose(fa_is_smaller, [fb, fa])
-
-        tol = 2 * eps_m * np.abs(xm) + eps_a
-        tlim = tol / np.abs(b - c)
-        terminate = np.logical_or(terminate, np.logical_or(fm == 0, tlim > 0.5))
-        if verbose:
-            output = "fm=%s\ntlim=%s\nterm=%s" % (fm, tlim, terminate)
-            print(output)
-
-        if np.all(terminate):
-            break
-        iterations += 1 - terminate
-
-        # Figure out values xi and phi
-        # to determine which method we should use next
-        xi = (a - b) / (c - b)
-        phi = (fa - fb) / (fc - fb)
-        iqi = np.logical_and(phi**2 < xi, (1 - phi)**2 < 1 - xi)
-
-        if not shape:
-            # scalar case
-            if iqi:
-                # inverse quadratic interpolation
-                t = fa / (fb - fa) * fc / (fb - fc) + (c - a) / \
-                    (b - a) * fa / (fc - fa) * fb / (fc - fb)
-            else:
-                # bisection
-                t = 0.5
-        else:
-            # array case
-            t = np.full(shape, 0.5)
-            a2, b2, c2, fa2, fb2, fc2 = a[iqi], b[iqi], c[iqi], fa[iqi], fb[iqi], fc[iqi]
-            t[iqi] = fa2 / (fb2 - fa2) * fc2 / (fb2 - fc2) + (c2 - a2) / \
-                (b2 - a2) * fa2 / (fc2 - fa2) * fb2 / (fc2 - fb2)
-
-        # limit to the range (tlim, 1-tlim)
-        t = np.minimum(1 - tlim, np.maximum(tlim, t))
-
-    # done!
-    if return_iter:
-        return xm, iterations
-    else:
-        return xm
 
 
 class GaussianKDE(ScipyModel):
@@ -236,88 +107,15 @@ class GaussianKDE(ScipyModel):
         uppers = ndtr((X[:, None] - self._model.dataset) / stdev)
         return (uppers - lower).dot(self._model.weights)
 
-    def _brentq_cdf(self, value):
-        """Helper function to compute percent_point.
-
-        As scipy.stats.gaussian_kde doesn't provide this functionality out of the box we need
-        to make a numerical approach:
-
-        - First we scalarize and bound cumulative_distribution.
-        - Then we define a function `f(x) = cdf(x) - value`, where value is the given argument.
-        - As value will be called from ppf we can assume value = cdf(z) for some z that is the
-        value we are searching for. Therefore the zeros of the function will be x such that:
-        cdf(x) - cdf(z) = 0 => (becasue cdf is monotonous and continous) x = z
-
-        Args:
-            value (float):
-                cdf value, that is, in [0,1]
-
-        Returns:
-            callable:
-                function whose zero is the ppf of value.
-        """
-        # The decorator expects an instance method, but usually are decorated before being bounded
-        bound_cdf = partial(scalarize(GaussianKDE.cumulative_distribution), self)
-
-        def f(x):
-            return bound_cdf(x) - value
-
-        return f
-
-    def percent_point_slow(self, U):
+    def percent_point(self, U, method="chandrupatla"):
         """Compute the inverse cumulative distribution value for each point in U.
 
         Arguments:
             U (numpy.ndarray):
                 Values for which the cumulative distribution will be computed.
                 It must have shape (n, 1) and values must be in [0,1].
-
-        Returns:
-            numpy.ndarray:
-                Inverse cumulative distribution values for points in U.
-
-        Raises:
-            NotFittedError:
-                if the model is not fitted.
-        """
-        self.check_fit()
-
-        if isinstance(U, np.ndarray):
-            if len(U.shape) == 1:
-                U = U.reshape([-1, 1])
-
-            if len(U.shape) == 2:
-                return np.fromiter(
-                    (self.percent_point_slow(u[0]) for u in U),
-                    np.dtype('float64')
-                )
-
-            else:
-                raise ValueError('Arrays of dimensionality higher than 2 are not supported.')
-
-        if np.any(U > 1.0) or np.any(U < 0.0):
-            raise ValueError("Expected values in range [0.0, 1.0].")
-
-        is_one = U >= 1.0 - EPSILON
-        is_zero = U <= EPSILON
-        is_valid = not (is_zero or is_one)
-
-        lower, upper = self._get_bounds()
-
-        X = np.zeros(U.shape)
-        X[is_one] = float("inf")
-        X[is_zero] = float("-inf")
-        X[is_valid] = brentq(self._brentq_cdf(U[is_valid]), lower, upper)
-
-        return X
-
-    def percent_point(self, U, method="bisect"):
-        """Compute the inverse cumulative distribution value for each point in U.
-
-        Arguments:
-            U (numpy.ndarray):
-                Values for which the cumulative distribution will be computed.
-                It must have shape (n, 1) and values must be in [0,1].
+            method (str):
+                Whether to use the `chandrupatla` or `bisect` solver.
 
         Returns:
             numpy.ndarray:
@@ -351,9 +149,9 @@ class GaussianKDE(ScipyModel):
             lower = np.full(U[is_valid].shape, lower)
             upper = np.full(U[is_valid].shape, upper)
             if method == "bisect":
-                X[is_valid] = _bisect(_f, lower, upper)
+                X[is_valid] = bisect(_f, lower, upper)
             else:
-                X[is_valid] = _chandrupatla(_f, lower, upper)
+                X[is_valid] = chandrupatla(_f, lower, upper)
 
         return X
 

--- a/tests/large_scale_evaluation.py
+++ b/tests/large_scale_evaluation.py
@@ -37,14 +37,14 @@ import random
 from datetime import datetime
 from urllib.parse import urljoin
 
+import boto3
 import numpy as np
 import pandas as pd
-from scipy.stats import ks_2samp
-
-import boto3
 import tabulate
 from botocore import UNSIGNED
 from botocore.client import Config
+from scipy.stats import ks_2samp
+
 from copulas import get_instance
 from copulas.multivariate import GaussianMultivariate, VineCopula
 from copulas.univariate import GaussianUnivariate

--- a/tests/large_scale_evaluation.py
+++ b/tests/large_scale_evaluation.py
@@ -37,14 +37,14 @@ import random
 from datetime import datetime
 from urllib.parse import urljoin
 
-import boto3
 import numpy as np
 import pandas as pd
+from scipy.stats import ks_2samp
+
+import boto3
 import tabulate
 from botocore import UNSIGNED
 from botocore.client import Config
-from scipy.stats import ks_2samp
-
 from copulas import get_instance
 from copulas.multivariate import GaussianMultivariate, VineCopula
 from copulas.univariate import GaussianUnivariate

--- a/tests/unit/bivariate/test_independence.py
+++ b/tests/unit/bivariate/test_independence.py
@@ -18,7 +18,7 @@ class TestIndependence(TestCase):
         assert instance.tau is None
 
     def test_fit(self):
-        """fit checks that the given values are independent."""
+        """Fit checks that the given values are independent."""
         # Setup
         instance = Independence()
         data = np.array([

--- a/tests/unit/optimize/test___init__.py
+++ b/tests/unit/optimize/test___init__.py
@@ -1,6 +1,7 @@
-import pytest
-import numpy as np
 from unittest import TestCase
+
+import numpy as np
+
 from copulas.optimize import bisect, chandrupatla
 
 
@@ -10,18 +11,19 @@ class TestOptimize(TestCase):
         """Find the zero of a line."""
         N = 100
         target = np.random.random(size=N)
+
         def _f(x):
-            return x-target
+            return x - target
         for optimizer in [bisect, chandrupatla]:
             with self.subTest(optimizer=optimizer):
                 x = optimizer(_f, np.zeros(shape=N), np.ones(shape=N))
-                assert np.abs(x-target).max() < 1e-6
+                assert np.abs(x - target).max() < 1e-6
 
     def test_polynomial(self):
         """Find the zero of a polynomial."""
         def _f(x):
-            return np.power(x-10.0, 3.0)
+            return np.power(x - 10.0, 3.0)
         for optimizer in [bisect, chandrupatla]:
             with self.subTest(optimizer=optimizer):
                 x = optimizer(_f, np.array([0.0]), np.array([100.0]))
-                assert np.abs(x-10.0).max() < 1e-6
+                assert np.abs(x - 10.0).max() < 1e-6

--- a/tests/unit/optimize/test___init__.py
+++ b/tests/unit/optimize/test___init__.py
@@ -1,0 +1,27 @@
+import pytest
+import numpy as np
+from unittest import TestCase
+from copulas.optimize import bisect, chandrupatla
+
+
+class TestOptimize(TestCase):
+
+    def test_uniform(self):
+        """Find the zero of a line."""
+        N = 100
+        target = np.random.random(size=N)
+        def _f(x):
+            return x-target
+        for optimizer in [bisect, chandrupatla]:
+            with self.subTest(optimizer=optimizer):
+                x = optimizer(_f, np.zeros(shape=N), np.ones(shape=N))
+                assert np.abs(x-target).max() < 1e-6
+
+    def test_polynomial(self):
+        """Find the zero of a polynomial."""
+        def _f(x):
+            return np.power(x-10.0, 3.0)
+        for optimizer in [bisect, chandrupatla]:
+            with self.subTest(optimizer=optimizer):
+                x = optimizer(_f, np.array([0.0]), np.array([100.0]))
+                assert np.abs(x-10.0).max() < 1e-6

--- a/tests/unit/univariate/test_base.py
+++ b/tests/unit/univariate/test_base.py
@@ -87,7 +87,7 @@ class TestUnivariate(TestCase):
         }
 
     def test_fit_constant(self):
-        """if constant values, replace methods."""
+        """If constant values, replace methods."""
         # Setup
         distribution = Univariate()
 
@@ -99,7 +99,7 @@ class TestUnivariate(TestCase):
         assert distribution._instance._is_constant()
 
     def test_fit_not_constant(self):
-        """if constant values, replace methods."""
+        """If constant values, replace methods."""
         # Setup
         distribution = Univariate()
 

--- a/tests/unit/univariate/test_gaussian_kde.py
+++ b/tests/unit/univariate/test_gaussian_kde.py
@@ -104,34 +104,6 @@ class TestGaussianKDE(TestCase):
 
         assert not distribution._is_constant()
 
-    @patch('copulas.univariate.gaussian_kde.scalarize', autospec=True)
-    @patch('copulas.univariate.gaussian_kde.partial', autospec=True)
-    def test__brentq_cdf(self, partial_mock, scalarize_mock):
-        """_brentq_cdf returns a function that computes the cdf of a scalar minus its argument."""
-        # Setup
-        instance = GaussianKDE()
-
-        def mock_partial_return_value(x):
-            return x
-
-        scalarize_mock.return_value = 'scalar_function'
-        partial_mock.return_value = mock_partial_return_value
-
-        # Run
-        result = instance._brentq_cdf(0.5)
-
-        # Check
-        assert callable(result)
-
-        # result uses the return_value of partial_mock, so every value returned
-        # is (x - 0.5)
-        assert result(1.0) == 0.5
-        assert result(0.5) == 0
-        assert result(0.0) == -0.5
-
-        scalarize_mock.assert_called_once_with(GaussianKDE.cumulative_distribution)
-        partial_mock.assert_called_once_with('scalar_function', instance)
-
     def test_cumulative_distribution(self):
         """cumulative_distribution evaluates with the model."""
         instance = GaussianKDE()
@@ -157,6 +129,17 @@ class TestGaussianKDE(TestCase):
         assert abs(cdf[1] - 1.0) < 0.1, "The 50% percentile should be the median."
         assert cdf[2] > 2.0, "The 0.999th percentile should be large."
 
+    def test_percent_point_bisect(self):
+        """percent_point evaluates with the model."""
+        instance = GaussianKDE()
+        instance.fit(np.array([0.5, 1.0, 1.5]))
+
+        cdf = instance.percent_point(np.array([0.001, 0.5, 0.999]), method='bisect')
+
+        assert cdf[0] < 0.0, "The 0.001th percentile should be small."
+        assert abs(cdf[1] - 1.0) < 0.1, "The 50% percentile should be the median."
+        assert cdf[2] > 2.0, "The 0.999th percentile should be large."
+
     def test_percent_point_invalid_value(self):
         """Evaluating an invalid value will raise ValueError."""
         fit_data = np.array([1, 2, 3, 4, 5])
@@ -166,11 +149,12 @@ class TestGaussianKDE(TestCase):
         with self.assertRaises(ValueError):
             instance.percent_point(np.array([2.]))
 
-    def test_percent_point_convergence(self):
+    def test_percent_point_invertibility(self):
         instance = GaussianKDE()
         instance.fit(sample_univariate_bimodal())
-        x = instance.percent_point(np.array([0.5]))
-        assert abs(instance.cumulative_distribution(x) - 0.5) < 0.01
+        cdf = np.random.random(size=1000)
+        x = instance.percent_point(cdf)
+        assert np.abs(instance.cumulative_distribution(x) - cdf).max() < 1e-6
 
     def test_percent_point_boundary_values(self):
         instance = GaussianKDE()

--- a/tests/unit/univariate/test_gaussian_kde.py
+++ b/tests/unit/univariate/test_gaussian_kde.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 from scipy.stats import gaussian_kde
 
+from copulas.datasets import sample_univariate_bimodal
 from copulas.univariate.gaussian_kde import GaussianKDE
 
 
@@ -164,6 +165,19 @@ class TestGaussianKDE(TestCase):
 
         with self.assertRaises(ValueError):
             instance.percent_point(np.array([2.]))
+
+    def test_percent_point_convergence(self):
+        instance = GaussianKDE()
+        instance.fit(sample_univariate_bimodal())
+        x = instance.percent_point(np.array([0.5]))
+        assert abs(instance.cumulative_distribution(x) - 0.5) < 0.01
+
+    def test_percent_point_boundary_values(self):
+        instance = GaussianKDE()
+        instance.fit(np.array([0.0, 0.5, 1.0]))
+        x = instance.percent_point(np.array([0.0, 1.0]))
+        assert x[0] == float("-inf")
+        assert x[1] == float("inf")
 
     @patch('copulas.univariate.gaussian_kde.gaussian_kde', autospec=True)
     def test_sample(self, kde_mock):


### PR DESCRIPTION
Resolve #200. I'm on vacation from FB (happy holidays @csala!) so I thought I'd take a look at this - I've been wanting to make this faster forever, this PR makes gaussian kde ~8x faster.

Here's some code for benchmarking it:

```
import numpy as np
from time import time
from copulas.univariate.gaussian_kde import GaussianKDE

X_train = np.random.uniform(size=1000)
X_test = np.random.uniform(size=1000)

model = GaussianKDE()
model.fit(X_train)

start = time()
y_slow = model.percent_point(X_test)
print(time() - start)

start = time()
y_fast = model.percent_point_fast(X_test)
print(time() - start)

np.abs(y_fast - y_slow).max()
```

The vectorized version of the ppf takes 0.332 seconds while the current version takes 2.898 seconds.