### PR TITLE
Selection subsampling

### DIFF
--- a/copulas/univariate/base.py
+++ b/copulas/univariate/base.py
@@ -35,6 +35,9 @@ class Univariate(object):
             Ignored if ``candidates`` is passed.
         random_seed (int):
             Random seed to use.
+        selection_sample_size (int):
+            Size of the subsample to use for candidate selection.
+            If ``None``, all the data is used.
     """
 
     PARAMETRIC = ParametricType.NON_PARAMETRIC
@@ -73,9 +76,11 @@ class Univariate(object):
         return candidates
 
     @store_args
-    def __init__(self, candidates=None, parametric=None, bounded=None, random_seed=None):
+    def __init__(self, candidates=None, parametric=None, bounded=None, random_seed=None,
+                 selection_sample_size=None):
         self.candidates = candidates or self._select_candidates(parametric, bounded)
         self.random_seed = random_seed
+        self.selection_sample_size = selection_sample_size
 
     @classmethod
     def __repr__(cls):
@@ -212,7 +217,12 @@ class Univariate(object):
             X (numpy.ndarray):
                 Values of the random variable. It must have shape (n, 1).
         """
-        self._instance = select_univariate(X, self.candidates)
+        if self.selection_sample_size and self.selection_sample_size < len(X):
+            selection_sample = np.random.choice(X, size=self.selection_sample_size)
+        else:
+            selection_sample = X
+
+        self._instance = select_univariate(selection_sample, self.candidates)
         self._instance.fit(X)
 
         self.fitted = True

--- a/tests/unit/univariate/test_base.py
+++ b/tests/unit/univariate/test_base.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest.mock import patch
 
 import numpy as np
 
@@ -14,7 +14,7 @@ from copulas.univariate.uniform import UniformUnivariate
 from tests import compare_nested_iterables
 
 
-class TestUnivariate(TestCase):
+class TestUnivariate:
 
     def test__select_candidates(self):
         # Run
@@ -109,6 +109,46 @@ class TestUnivariate(TestCase):
         # Assert
         assert distribution.fitted
         assert not distribution._instance._is_constant()
+
+    @patch('copulas.univariate.base.select_univariate')
+    def test_fit_selection_sample_size_small(self, select_mock):
+        """if selection_sample_size is smaller than data, subsample the data before selecting."""
+        # Setup
+        distribution = Univariate(selection_sample_size=3)
+
+        # Run
+        distribution.fit(np.array([1, 1, 1, 1, 1]))
+
+        # Assert
+        assert distribution.fitted
+        assert distribution._instance == select_mock.return_value
+
+        call_args = select_mock.call_args_list
+        selection_sample = call_args[0][0][0]
+        np.testing.assert_array_equal(selection_sample, np.array([1, 1, 1]))
+
+        fit_call_args = select_mock.return_value.fit.call_args_list
+        np.testing.assert_array_equal(fit_call_args[0][0][0], np.array([1, 1, 1, 1, 1]))
+
+    @patch('copulas.univariate.base.select_univariate')
+    def test_fit_selection_sample_size_large(self, select_mock):
+        """if selection_sample_size is smaller than data, subsample the data before selecting."""
+        # Setup
+        distribution = Univariate(selection_sample_size=10)
+
+        # Run
+        distribution.fit(np.array([1, 1, 1, 1, 1]))
+
+        # Assert
+        assert distribution.fitted
+        assert distribution._instance == select_mock.return_value
+
+        call_args = select_mock.call_args_list
+        selection_sample = call_args[0][0][0]
+        np.testing.assert_array_equal(selection_sample, np.array([1, 1, 1, 1, 1]))
+
+        fit_call_args = select_mock.return_value.fit.call_args_list
+        np.testing.assert_array_equal(fit_call_args[0][0][0], np.array([1, 1, 1, 1, 1]))
 
     def test_check_constant_value(self):
         """check_constant_value return True if the array is constant."""


### PR DESCRIPTION
Resolve #183 

Add an argument to optionally use a sub-sample of the input data for univariate selection. The argument defaults to `None`, meaning that all the data will continue to be used by default.