### PR TITLE
Univariate constant value from dict

### DIFF
--- a/copulas/univariate/base.py
+++ b/copulas/univariate/base.py
@@ -621,6 +621,7 @@ class ScipyModel(Univariate, ABC):
         """
         self._params = params.copy()
         if self._is_constant():
-            self._replace_constant_methods()
+            constant = self._extract_constant()
+            self._set_constant_value(constant)
         else:
             self._model = self._get_model()

--- a/copulas/univariate/beta.py
+++ b/copulas/univariate/beta.py
@@ -35,3 +35,6 @@ class BetaUnivariate(ScipyModel):
 
     def _is_constant(self):
         return self._params['scale'] == 0
+
+    def _extract_constant(self):
+        return self._params['loc']

--- a/copulas/univariate/gamma.py
+++ b/copulas/univariate/gamma.py
@@ -31,3 +31,6 @@ class GammaUnivariate(ScipyModel):
 
     def _is_constant(self):
         return self._params['scale'] == 0
+
+    def _extract_constant(self):
+        return self._params['loc']

--- a/copulas/univariate/gaussian.py
+++ b/copulas/univariate/gaussian.py
@@ -26,3 +26,6 @@ class GaussianUnivariate(ScipyModel):
 
     def _is_constant(self):
         return self._params['scale'] == 0
+
+    def _extract_constant(self):
+        return self._params['loc']

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -170,3 +170,6 @@ class GaussianKDE(ScipyModel):
 
     def _is_constant(self):
         return len(np.unique(self._params['dataset'])) == 1
+
+    def _extract_constant(self):
+        return self._params['dataset'][0]

--- a/copulas/univariate/log_laplace.py
+++ b/copulas/univariate/log_laplace.py
@@ -31,3 +31,6 @@ class LogLaplace(ScipyModel):
 
     def _is_constant(self):
         return self._params['scale'] == 0
+
+    def _extract_constant(self):
+        return self._params['loc']

--- a/copulas/univariate/student_t.py
+++ b/copulas/univariate/student_t.py
@@ -28,3 +28,6 @@ class StudentTUnivariate(ScipyModel):
 
     def _is_constant(self):
         return self._params['scale'] == 0
+
+    def _extract_constant(self):
+        return self._params['loc']

--- a/copulas/univariate/truncated_gaussian.py
+++ b/copulas/univariate/truncated_gaussian.py
@@ -63,3 +63,6 @@ class TruncatedGaussian(ScipyModel):
 
     def _is_constant(self):
         return self._params['a'] == self._params['b']
+
+    def _extract_constant(self):
+        return self._params['loc']

--- a/copulas/univariate/uniform.py
+++ b/copulas/univariate/uniform.py
@@ -26,3 +26,6 @@ class UniformUnivariate(ScipyModel):
 
     def _is_constant(self):
         return self._params['scale'] == 0
+
+    def _extract_constant(self):
+        return self._params['loc']

--- a/tests/end-to-end/univariate/test_beta.py
+++ b/tests/end-to-end/univariate/test_beta.py
@@ -86,6 +86,24 @@ class TestGaussian(TestCase):
         cdf2 = model2.cumulative_distribution(sampled_data)
         assert np.all(np.isclose(cdf, cdf2, atol=0.01))
 
+    def test_to_dict_from_dict_constant(self):
+        model = BetaUnivariate()
+        model.fit(self.constant)
+
+        sampled_data = model.sample(50)
+        pdf = model.probability_density(sampled_data)
+        cdf = model.cumulative_distribution(sampled_data)
+
+        params = model.to_dict()
+        model2 = BetaUnivariate.from_dict(params)
+
+        np.testing.assert_equal(np.full(50, 5), sampled_data)
+        np.testing.assert_equal(np.full(50, 5), model2.sample(50))
+        np.testing.assert_equal(np.full(50, 1), pdf)
+        np.testing.assert_equal(np.full(50, 1), model2.probability_density(sampled_data))
+        np.testing.assert_equal(np.full(50, 1), cdf)
+        np.testing.assert_equal(np.full(50, 1), model2.cumulative_distribution(sampled_data))
+
     def test_to_dict_constant(self):
         model = BetaUnivariate()
         model.fit(self.constant)

--- a/tests/end-to-end/univariate/test_gamma.py
+++ b/tests/end-to-end/univariate/test_gamma.py
@@ -98,6 +98,24 @@ class TestGaussian(TestCase):
             'a': 0,
         }
 
+    def test_to_dict_from_dict_constant(self):
+        model = GammaUnivariate()
+        model.fit(self.constant)
+
+        sampled_data = model.sample(50)
+        pdf = model.probability_density(sampled_data)
+        cdf = model.cumulative_distribution(sampled_data)
+
+        params = model.to_dict()
+        model2 = GammaUnivariate.from_dict(params)
+
+        np.testing.assert_equal(np.full(50, 5), sampled_data)
+        np.testing.assert_equal(np.full(50, 5), model2.sample(50))
+        np.testing.assert_equal(np.full(50, 1), pdf)
+        np.testing.assert_equal(np.full(50, 1), model2.probability_density(sampled_data))
+        np.testing.assert_equal(np.full(50, 1), cdf)
+        np.testing.assert_equal(np.full(50, 1), model2.cumulative_distribution(sampled_data))
+
     def test_save_load(self):
         model = GammaUnivariate()
         model.fit(self.data)

--- a/tests/end-to-end/univariate/test_gaussian.py
+++ b/tests/end-to-end/univariate/test_gaussian.py
@@ -84,6 +84,24 @@ class TestGaussian(TestCase):
         cdf2 = model2.cumulative_distribution(sampled_data)
         assert np.all(np.isclose(cdf, cdf2, atol=0.01))
 
+    def test_to_dict_from_dict_constant(self):
+        model = GaussianUnivariate()
+        model.fit(self.constant)
+
+        sampled_data = model.sample(50)
+        pdf = model.probability_density(sampled_data)
+        cdf = model.cumulative_distribution(sampled_data)
+
+        params = model.to_dict()
+        model2 = GaussianUnivariate.from_dict(params)
+
+        np.testing.assert_equal(np.full(50, 5), sampled_data)
+        np.testing.assert_equal(np.full(50, 5), model2.sample(50))
+        np.testing.assert_equal(np.full(50, 1), pdf)
+        np.testing.assert_equal(np.full(50, 1), model2.probability_density(sampled_data))
+        np.testing.assert_equal(np.full(50, 1), cdf)
+        np.testing.assert_equal(np.full(50, 1), model2.cumulative_distribution(sampled_data))
+
     def test_to_dict_constant(self):
         model = GaussianUnivariate()
         model.fit(self.constant)

--- a/tests/end-to-end/univariate/test_gaussian_kde.py
+++ b/tests/end-to-end/univariate/test_gaussian_kde.py
@@ -103,6 +103,24 @@ class TestGaussian(TestCase):
             'dataset': [5] * 100
         }
 
+    def test_to_dict_from_dict_constant(self):
+        model = GaussianKDE()
+        model.fit(self.constant)
+
+        sampled_data = model.sample(50)
+        pdf = model.probability_density(sampled_data)
+        cdf = model.cumulative_distribution(sampled_data)
+
+        params = model.to_dict()
+        model2 = GaussianKDE.from_dict(params)
+
+        np.testing.assert_equal(np.full(50, 5), sampled_data)
+        np.testing.assert_equal(np.full(50, 5), model2.sample(50))
+        np.testing.assert_equal(np.full(50, 1), pdf)
+        np.testing.assert_equal(np.full(50, 1), model2.probability_density(sampled_data))
+        np.testing.assert_equal(np.full(50, 1), cdf)
+        np.testing.assert_equal(np.full(50, 1), model2.cumulative_distribution(sampled_data))
+
     def test_save_load(self):
         model = GaussianKDE()
         model.fit(self.data)

--- a/tests/end-to-end/univariate/test_student_t.py
+++ b/tests/end-to-end/univariate/test_student_t.py
@@ -85,6 +85,24 @@ class TestStudentT(TestCase):
         cdf2 = model2.cumulative_distribution(sampled_data)
         assert np.all(np.isclose(cdf, cdf2, atol=0.01))
 
+    def test_to_dict_from_dict_constant(self):
+        model = StudentTUnivariate()
+        model.fit(self.constant)
+
+        sampled_data = model.sample(50)
+        pdf = model.probability_density(sampled_data)
+        cdf = model.cumulative_distribution(sampled_data)
+
+        params = model.to_dict()
+        model2 = StudentTUnivariate.from_dict(params)
+
+        np.testing.assert_equal(np.full(50, 5), sampled_data)
+        np.testing.assert_equal(np.full(50, 5), model2.sample(50))
+        np.testing.assert_equal(np.full(50, 1), pdf)
+        np.testing.assert_equal(np.full(50, 1), model2.probability_density(sampled_data))
+        np.testing.assert_equal(np.full(50, 1), cdf)
+        np.testing.assert_equal(np.full(50, 1), model2.cumulative_distribution(sampled_data))
+
     def test_to_dict_constant(self):
         model = StudentTUnivariate()
         model.fit(self.constant)

--- a/tests/end-to-end/univariate/test_truncated_gaussian.py
+++ b/tests/end-to-end/univariate/test_truncated_gaussian.py
@@ -86,6 +86,24 @@ class TestGaussian(TestCase):
         cdf2 = model2.cumulative_distribution(sampled_data)
         assert np.all(np.isclose(cdf, cdf2, atol=0.01))
 
+    def test_to_dict_from_dict_constant(self):
+        model = TruncatedGaussian()
+        model.fit(self.constant)
+
+        sampled_data = model.sample(50)
+        pdf = model.probability_density(sampled_data)
+        cdf = model.cumulative_distribution(sampled_data)
+
+        params = model.to_dict()
+        model2 = TruncatedGaussian.from_dict(params)
+
+        np.testing.assert_equal(np.full(50, 5), sampled_data)
+        np.testing.assert_equal(np.full(50, 5), model2.sample(50))
+        np.testing.assert_equal(np.full(50, 1), pdf)
+        np.testing.assert_equal(np.full(50, 1), model2.probability_density(sampled_data))
+        np.testing.assert_equal(np.full(50, 1), cdf)
+        np.testing.assert_equal(np.full(50, 1), model2.cumulative_distribution(sampled_data))
+
     def test_to_dict_constant(self):
         model = TruncatedGaussian(min=1, max=5)
         model.fit(self.constant)

--- a/tests/unit/univariate/test_beta.py
+++ b/tests/unit/univariate/test_beta.py
@@ -48,3 +48,16 @@ class TestBetaUnivariate(TestCase):
         distribution.fit(np.array([1, 2, 3, 4]))
 
         assert not distribution._is_constant()
+
+    def test__extract_constant(self):
+        distribution = BetaUnivariate()
+        distribution._params = {
+            'loc': 1,
+            'scale': 1,
+            'a': 1,
+            'b': 1
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant

--- a/tests/unit/univariate/test_gamma.py
+++ b/tests/unit/univariate/test_gamma.py
@@ -46,3 +46,15 @@ class TestGammaUnivariate(TestCase):
         distribution.fit(np.array([1, 2, 3, 4]))
 
         assert not distribution._is_constant()
+
+    def test__extract_constant(self):
+        distribution = GammaUnivariate()
+        distribution._params = {
+            'loc': 1,
+            'scale': 1,
+            'a': 1,
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant

--- a/tests/unit/univariate/test_gaussian.py
+++ b/tests/unit/univariate/test_gaussian.py
@@ -42,3 +42,14 @@ class TestGaussianUnivariate(TestCase):
         distribution.fit(np.array([1, 2, 3, 4]))
 
         assert not distribution._is_constant()
+
+    def test__extract_constant(self):
+        distribution = GaussianUnivariate()
+        distribution._params = {
+            'loc': 1,
+            'scale': 0
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant

--- a/tests/unit/univariate/test_gaussian_kde.py
+++ b/tests/unit/univariate/test_gaussian_kde.py
@@ -192,3 +192,13 @@ class TestGaussianKDE(TestCase):
         input_array = instance._model.evaluate.call_args[0][0]
         np.testing.assert_equal(input_array, np.array([1, 2, 3]))
         np.testing.assert_equal(pdf, np.array([0.1, 0.2, 0.3]))
+
+    def test__extract_constant(self):
+        distribution = GaussianKDE()
+        distribution._params = {
+            'dataset': [1, 1, 1, 1],
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant

--- a/tests/unit/univariate/test_log_laplace.py
+++ b/tests/unit/univariate/test_log_laplace.py
@@ -46,3 +46,15 @@ class TestLogLaplaceUnivariate(TestCase):
         distribution.fit(np.array([1, 2, 3, 4]))
 
         assert not distribution._is_constant()
+
+    def test__extract_constant(self):
+        distribution = LogLaplace()
+        distribution._params = {
+            'c': 2,
+            'loc': 1,
+            'scale': 0
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant

--- a/tests/unit/univariate/test_student_t.py
+++ b/tests/unit/univariate/test_student_t.py
@@ -35,3 +35,15 @@ class TestStudentTUnivariate(TestCase):
         distribution.fit(np.array([1, 2, 3, 4]))
 
         assert not distribution._is_constant()
+
+    def test__extract_constant(self):
+        distribution = StudentTUnivariate()
+        distribution._params = {
+            'df': 1,
+            'loc': 1,
+            'scale': 0
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant

--- a/tests/unit/univariate/test_truncated_gaussian.py
+++ b/tests/unit/univariate/test_truncated_gaussian.py
@@ -48,3 +48,16 @@ class TestTruncatedGaussian(TestCase):
         distribution.fit(np.array([1, 2, 3, 4]))
 
         assert not distribution._is_constant()
+
+    def test__extract_constant(self):
+        distribution = TruncatedGaussian()
+        distribution._params = {
+            'a': 1,
+            'b': 1,
+            'loc': 1,
+            'scale': 0
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant

--- a/tests/unit/univariate/test_uniform.py
+++ b/tests/unit/univariate/test_uniform.py
@@ -44,3 +44,14 @@ class TestUniformUnivariate(TestCase):
         distribution.fit(np.array([1, 2, 3, 4]))
 
         assert not distribution._is_constant()
+
+    def test__extract_constant(self):
+        distribution = UniformUnivariate()
+        distribution._params = {
+            'loc': 1,
+            'scale': 0
+        }
+
+        constant = distribution._extract_constant()
+
+        assert 1 == constant


### PR DESCRIPTION
Resolve #212 

Make sure that ScipyModel univariates restore the constant_value attribute when being built from a dict that specifies a degenerate distribution.