### PR TITLE
lei-1126

### DIFF
--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+import pandas as pd
 from scipy.special import ndtr
 from scipy.stats import gaussian_kde
 
@@ -101,9 +102,17 @@ class GaussianKDE(ScipyModel):
         self.check_fit()
         X = np.array(X)
         stdev = np.sqrt(self._model.covariance[0, 0])
-        lower = ndtr((self._get_bounds()[0] - self._model.dataset) / stdev)[0]
-        uppers = ndtr((X[:, None] - self._model.dataset) / stdev)
-        return (uppers - lower).dot(self._model.weights)
+        # lower = ndtr((self._get_bounds()[0] - self._model.dataset) / stdev)[0]
+        # uppers = ndtr((X[:, None] - self._model.dataset) / stdev)
+        # return (uppers - lower).dot(self._model.weights)
+
+        l = pd.Series(self._model.dataset.flatten())
+        v_c = l.value_counts()
+        weights = v_c.values / l.__len__()
+        dataset_weighted = np.array(v_c.index).reshape(1, -1)
+        lower = ndtr((self._get_bounds()[0] - dataset_weighted) / stdev)[0]
+        uppers = ndtr((X[:, None] - dataset_weighted) / stdev)
+        return (uppers - lower).dot(weights)
 
     def percent_point(self, U, method="chandrupatla"):
         """Compute the inverse cumulative distribution value for each point in U.

--- a/copulas/univariate/gaussian_kde.py
+++ b/copulas/univariate/gaussian_kde.py
@@ -106,9 +106,9 @@ class GaussianKDE(ScipyModel):
         # uppers = ndtr((X[:, None] - self._model.dataset) / stdev)
         # return (uppers - lower).dot(self._model.weights)
 
-        l = pd.Series(self._model.dataset.flatten())
-        v_c = l.value_counts()
-        weights = v_c.values / l.__len__()
+        data_flatten = pd.Series(self._model.dataset.flatten())
+        v_c = data_flatten.value_counts()
+        weights = v_c.values / data_flatten.__len__()
         dataset_weighted = np.array(v_c.index).reshape(1, -1)
         lower = ndtr((self._get_bounds()[0] - dataset_weighted) / stdev)[0]
         uppers = ndtr((X[:, None] - dataset_weighted) / stdev)


### PR DESCRIPTION
Hi, I have used the package copulas when I need to simulate real data. I used GaussianMultivariate to fit, and then sampled data by GaussianMultivariate.sample(),but I found it was very slow when I used 20000 samples(10 features) for fitting to generate 20000 simulation data. I found that a lot time was spent in calculating the cumulative distribution function. So I modified some source code in the module gaussian_kde.py to improve the speed. In the end, my simulation speed increased by about 100 times.

Of course, as my data are all integers, so for a variable, there are many samples with the same value and I can count each value to redefine the weight. Although copula is  used for continuous data, In real situations, data of int type is often used for fitting, and most of the values are the same for one variable, especially when there is lot of training data. In such situation, the simulation speed will increase a lot if we use the modified code.

best wishes