### PR TITLE
Add `flake8-variables-names`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ universal = 1
 max-line-length = 99
 exclude = docs, .git, __pycache__, .ipynb_checkpoints
 ignore = W503
+extend-ignore = VNE001 # Single letter variable names are not allowed
 
 [isort]
 line_length = 99

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ development_requires = [
     'flake8-builtins>=1.5.3,<1.6',
     'flake8-eradicate>=1.1.0,<1.2',
     'flake8-quotes>=3.3.0,<4',
+    'flake8-variables-names>=0.0.4,<0.1',
 
     # fix style issues
     'autoflake>=1.1,<2',


### PR DESCRIPTION
As part of #278, added `flake8-variables-names` addon. Rule VNE001 is being ignored for complaining about reasonable names like X and Y (discussed [here](https://github.com/sdv-dev/SDMetrics/pull/97#issuecomment-964123115)).