### PR TITLE
Fixing docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Generate Docs
 on:
   push:
     branches: [ stable ]
+  workflow_dispatch:
 
 jobs:
   docs:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,1 +1,4 @@
+Authors
+=======
+
 See: https://github.com/sdv-dev/Copulas/graphs/contributors

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+<p style="text-align:center">
     <i>This repository is part of <a href="https://sdv.dev">The Synthetic Data Vault Project</a>, a project from <a href="https://datacebo.com">DataCebo</a>.</i>
 </p>
 
@@ -10,12 +10,11 @@
 [![Slack](https://img.shields.io/badge/Community-Slack-blue?style=plastic&logo=slack)](https://bit.ly/sdv-slack-invite)
 
 <br/>
-<p align="center">
+<p style="text-align:center">
 <a href="https://github.com/sdv-dev/Copulas">
-<img align="center" width=40% src="https://github.com/sdv-dev/SDV/blob/master/docs/images/Copulas-DataCebo.png"></img>
+<img width=40% src="https://github.com/sdv-dev/SDV/blob/master/docs/images/Copulas-DataCebo.png?raw=true"></img>
 </a>
 </p>
-
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<div align="center">
-<br/>
 <p align="center">
     <i>This repository is part of <a href="https://sdv.dev">The Synthetic Data Vault Project</a>, a project from <a href="https://datacebo.com">DataCebo</a>.</i>
 </p>
@@ -11,16 +9,13 @@
 [![Coverage Status](https://codecov.io/gh/sdv-dev/Copulas/branch/master/graph/badge.svg)](https://codecov.io/gh/sdv-dev/Copulas)
 [![Slack](https://img.shields.io/badge/Community-Slack-blue?style=plastic&logo=slack)](https://bit.ly/sdv-slack-invite)
 
-<div align="left">
 <br/>
 <p align="center">
 <a href="https://github.com/sdv-dev/Copulas">
 <img align="center" width=40% src="https://github.com/sdv-dev/SDV/blob/master/docs/images/Copulas-DataCebo.png"></img>
 </a>
 </p>
-</div>
 
-</div>
 
 # Overview
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. mdinclude:: ../README.md
-   :end-line: 42
+   :end-line: 48
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 .. mdinclude:: ../README.md
-   :end-line: 62
+   :end-line: 42
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
resolves #341 
**Note**: the bar with the badges wraps around because sphinx has a fixed max width of 800px. The readme should not appear that way on the site
<img width="623" alt="Screenshot 2023-05-18 at 5 11 23 PM" src="https://github.com/sdv-dev/Copulas/assets/7800528/0e2ba19f-c081-4a6d-adfe-4aca1f826dab">
