### PR TITLE
When Copulas univariate fit fails, produce a log instead of a warning

### DIFF
--- a/copulas/multivariate/gaussian.py
+++ b/copulas/multivariate/gaussian.py
@@ -2,7 +2,6 @@
 
 import logging
 import sys
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -112,11 +111,11 @@ class GaussianMultivariate(Multivariate):
             try:
                 univariate.fit(column)
             except BaseException:
-                warning_message = (
+                log_message = (
                     f'Unable to fit to a {distribution} distribution for column {column_name}. '
                     'Using a Gaussian distribution instead.'
                 )
-                warnings.warn(warning_message)
+                LOGGER.info(log_message)
                 univariate = GaussianUnivariate()
                 univariate.fit(column)
 

--- a/tests/end-to-end/multivariate/test_gaussian.py
+++ b/tests/end-to-end/multivariate/test_gaussian.py
@@ -179,8 +179,8 @@ class TestGaussian(TestCase):
 
 
 @patch('copulas.univariate.truncated_gaussian.TruncatedGaussian._fit')
-@patch('copulas.multivariate.gaussian.warnings')
-def test_broken_distribution(warnings_mock, truncated_mock):
+@patch('copulas.multivariate.gaussian.LOGGER')
+def test_broken_distribution(logger_mock, truncated_mock):
     """Fit should use a gaussian if the passed distribution crashes."""
     # Setup
     truncated_mock.side_effect = ValueError()
@@ -194,11 +194,14 @@ def test_broken_distribution(warnings_mock, truncated_mock):
     samples = model.sample()
 
     # Asserts
-    expected_warnings_msg = (
+    expected_logging_msg = (
         'Unable to fit to a copulas.univariate.truncated_gaussian.TruncatedGaussian '
         'distribution for column y. Using a Gaussian distribution instead.'
     )
-    warnings_mock.warn.assert_called_once_with(expected_warnings_msg)
+    calls = logger_mock.info.call_args_list
+    assert calls[0].args[0] == 'Fitting %s'
+    assert calls[1].args[0] == expected_logging_msg
+    assert len(calls) == 2
 
     expected_model = GaussianMultivariate(
         distribution={'y': 'copulas.univariate.truncated_gaussian.TruncatedGaussian'}


### PR DESCRIPTION
Resolve #359