### PR TITLE
Add workflow to release Copulas on PyPI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,6 +84,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+
       - name: Bump to next candidate
         run: |
           make bumpversion-candidate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,7 +84,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
-          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
+          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
     
       - name: Bump to next candidate
         if: ${{ inputs.candidate && !inputs.test_pypi }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -71,7 +74,6 @@ jobs:
 
       - name: Create wheel
         run: |
-          git checkout main
           make check-main
           make dist
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,80 +1,27 @@
-# name: Generate Docs
-
-# on:
-#   push:
-#     branches: [ stable ]
-#   workflow_dispatch:
-
-# jobs:
-#   docs:
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: actions/checkout@v4
-#     - name: Set up Python 3.9
-#       uses: actions/setup-python@v5
-#       with:
-#         python-version: 3.9
-#     - name: Build
-#       run: |
-#         sudo apt-get install pandoc
-#         python -m pip install --upgrade pip
-#         pip install -e .[dev]
-#         make docs
-#     - name: Deploy
-#       uses: peaceiris/actions-gh-pages@v3
-#       with:
-#         github_token: ${{secrets.GITHUB_TOKEN}}
-#         publish_dir: docs/_build/html
-name: Release
+name: Generate Docs
 
 on:
-  release:
-    types: [published]
-
+  push:
+    branches: [ stable ]
   workflow_dispatch:
-    inputs:
-      candidate:
-        description: 'If true, this creates a release candidate.'
-        required: true
-        type: boolean
-        default: true
-      test_pypi:
-        description: 'If true, this will push to the test pypi instead of regular.'
-        type: boolean
-        default: true
 
 jobs:
-  release:
+  docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.candidate && 'main-clone' || 'stable' }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: |
-            python -m pip install --upgrade pip
-            python -m pip install .[dev]
-
-      - name: Create wheel
-        run: |
-          make dist
-
-      - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
-          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
-
-      - name: Bump version to next candidate
-        if: ${{ inputs.candidate && inputs.test_pypi }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          make bumpversion-candidate
-          make git-push
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+    - name: Build
+      run: |
+        sudo apt-get install pandoc
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+        make docs
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        publish_dir: docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,9 @@
 name: Release
 
 on:
+  release:
+    types: [published]
+
   workflow_dispatch:
     inputs:
       candidate:
@@ -38,7 +41,7 @@ on:
       test_pypi:
         description: 'If true, this will push to the test pypi instead of regular.'
         type: boolean
-        default: false
+        default: true
 
 jobs:
   release:
@@ -46,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main-clone
+          ref: ${{ inputs.candidate && 'main-clone' || 'stable' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -57,24 +60,6 @@ jobs:
         run: |
             python -m pip install --upgrade pip
             python -m pip install .[dev]
-
-      - name: Configure Git user
-        run: |
-          git config user.name "SDV Team"
-          git config user.email "dataceboteam@gmail.com"
-          git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
-
-      - name: Merge main to stable and push tags
-        # if: ${{ !inputs.candidate && !inputs.test_pypi }}
-        if: ${{ !inputs.candidate }}
-        run: |
-          make check-clean
-          make check-candidate
-          make check-history
-          git checkout stable-clone || git checkout -b stable-clone
-          git merge --no-ff main-clone -m"make release-tag: Merge branch 'main' into stable"
-          make bumpversion-release
-          git push --tags origin stable-clone
 
       - name: Create wheel
         run: |
@@ -90,13 +75,35 @@ jobs:
         if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           make bumpversion-candidate
-          make git-push
-    
-      - name: Merge to main and bump to next patch
-        # if: ${{ !inputs.candidate && !inputs.test_pypi }}
-        if: ${{ !inputs.candidate }}
+
+      - name: Get last commit message
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
+        id: get_message
         run: |
-          git checkout main-clone
-          git merge stable-clone
-          make bumpversion-patch
-          make git-push
+          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          echo "commit_message<<EOF" >> $GITHUB_ENV
+          echo "$COMMIT_MESSAGE" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create PR for candidate
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
+        id: bump-candidate-pr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          commit-message: ${{ env.commit_message }}
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          title: ${{ env.commit_message }}
+          body: "This is an auto-generated PR to bump the version to the next release candidate."
+          branch: bump-release-candidate
+          branch-suffix: short-commit-hash
+          base: main
+
+      - name: Enable Pull Request Automerge
+        if: steps.bump-candidate-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          pull-request-number: ${{ steps.bump-candidate-pr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,14 +70,25 @@ jobs:
         with:
           password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
           repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
-    
+  
+  bump-candidate:
+    if: ${{ inputs.candidate }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 'main-clone'
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Bump to next candidate
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           make bumpversion-candidate
 
       - name: Get last commit message
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
         id: get_message
         run: |
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
@@ -86,7 +97,6 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create PR for candidate
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
         id: bump-candidate-pr
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Create wheel
         run: |
+          git checkout main
           make check-main
           make dist
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,7 +72,7 @@ jobs:
           repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
 
       - name: Bump version to next candidate
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
+        if: ${{ inputs.candidate && inputs.test_pypi }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -70,55 +70,11 @@ jobs:
         with:
           password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
           repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
-  
-  bump-candidate:
-    if: ${{ inputs.candidate }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: 'main-clone'
 
-      - name: Configure Git user
+      - name: Bump version to next candidate
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install .[dev]
-
-      - name: Bump to next candidate
-        run: |
           make bumpversion-candidate
-
-      - name: Get last commit message
-        id: get_message
-        run: |
-          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
-          echo "commit_message<<EOF" >> $GITHUB_ENV
-          echo "$COMMIT_MESSAGE" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Create PR for candidate
-        id: bump-candidate-pr
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          commit-message: ${{ env.commit_message }}
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          title: ${{ env.commit_message }}
-          body: "This is an auto-generated PR to bump the version to the next release candidate."
-          branch: bump-release-candidate
-          branch-suffix: short-commit-hash
-          base: main
-
-      - name: Enable Pull Request Automerge
-        if: steps.bump-candidate-pr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          pull-request-number: ${{ steps.bump-candidate-pr.outputs.pull-request-number }}
-          merge-method: squash
+          make git-push

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,7 +78,6 @@ jobs:
 
       - name: Create wheel
         run: |
-          git checkout main-clone
           make dist
 
       - name: Publish a Python distribution to PyPI

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,8 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
 
       - name: Merge main to stable and push tags
-        if: ${{ !inputs.candidate && !inputs.test_pypi }}
+        # if: ${{ !inputs.candidate && !inputs.test_pypi }}
+        if: ${{ !inputs.candidate }}
         run: |
           make check-clean
           make check-candidate
@@ -93,7 +94,8 @@ jobs:
           make git-push
     
       - name: Merge to main and bump to next patch
-        if: ${{ !inputs.candidate && !inputs.test_pypi}}
+        # if: ${{ !inputs.candidate && !inputs.test_pypi }}
+        if: ${{ !inputs.candidate }}
         run: |
           git checkout main-clone
           git merge stable-clone

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,27 +1,94 @@
-name: Generate Docs
+# name: Generate Docs
+
+# on:
+#   push:
+#     branches: [ stable ]
+#   workflow_dispatch:
+
+# jobs:
+#   docs:
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v4
+#     - name: Set up Python 3.9
+#       uses: actions/setup-python@v5
+#       with:
+#         python-version: 3.9
+#     - name: Build
+#       run: |
+#         sudo apt-get install pandoc
+#         python -m pip install --upgrade pip
+#         pip install -e .[dev]
+#         make docs
+#     - name: Deploy
+#       uses: peaceiris/actions-gh-pages@v3
+#       with:
+#         github_token: ${{secrets.GITHUB_TOKEN}}
+#         publish_dir: docs/_build/html
+name: Release
 
 on:
-  push:
-    branches: [ stable ]
   workflow_dispatch:
+    inputs:
+      candidate:
+        description: 'If true, this creates a release candidate.'
+        required: true
+        type: boolean
+        default: true
+      test_pypi:
+        description: 'If true, this will push to the test pypi instead of regular.'
+        type: boolean
+        default: false
 
 jobs:
-  docs:
+  release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    - name: Build
-      run: |
-        sudo apt-get install pandoc
-        python -m pip install --upgrade pip
-        pip install -e .[dev]
-        make docs
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{secrets.GITHUB_TOKEN}}
-        publish_dir: docs/_build/html
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install .[dev]
+
+      - name: Configure Git user
+        run: |
+          git config user.name "SDV Team"
+          git config user.email "dataceboteam@gmail.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
+
+      - name: Merge main to stable and push tags
+        if: ${{ !inputs.candidate && !inputs.test_pypi }}
+        run: |
+          make check-release
+          make git-merge-main-stable
+          make bumpversion-release
+          make git-push-tags-stable
+
+      - name: Create wheel
+        run: |
+          make check-main
+          make dist
+
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
+          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
+    
+      - name: Bump to next candidate
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
+        run: |
+          make bumpversion-candidate
+          make git-push
+    
+      - name: Merge to main and bump to next patch
+        if: ${{ !inputs.candidate && !inputs.test_pypi}}
+        run: |
+          make git-merge-stable-main
+          make bumpversion-patch
+          make git-push

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: main-clone
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,15 +67,17 @@ jobs:
       - name: Merge main to stable and push tags
         if: ${{ !inputs.candidate && !inputs.test_pypi }}
         run: |
-          make check-release
-          make git-merge-main-stable
+          make check-clean
+          make check-candidate
+          make check-history
+          git checkout stable-clone || git checkout -b stable-clone
+          git merge --no-ff main-clone -m"make release-tag: Merge branch 'main' into stable"
           make bumpversion-release
-          make git-push-tags-stable
+          git push --tags origin stable-clone
 
       - name: Create wheel
         run: |
-          make check-branch
-          make check-main
+          git checkout main-clone
           make dist
 
       - name: Publish a Python distribution to PyPI
@@ -93,6 +95,7 @@ jobs:
       - name: Merge to main and bump to next patch
         if: ${{ !inputs.candidate && !inputs.test_pypi}}
         run: |
-          make git-merge-stable-main
+          git checkout main-clone
+          git merge stable-clone
           make bumpversion-patch
           make git-push

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Create wheel
         run: |
+          make check-branch
           make check-main
           make dist
 

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -18,9 +18,9 @@ jobs:
           - os: macos-latest
             python-version: '3.13'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   minimum:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -22,9 +22,9 @@ jobs:
           - os: macos-latest
             python-version: '3.13'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/numerical.yml
+++ b/.github/workflows/numerical.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/numerical.yml
+++ b/.github/workflows/numerical.yml
@@ -22,9 +22,9 @@ jobs:
           - os: macos-latest
             python-version: '3.13'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -61,7 +61,7 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
 
       - name: Merge main to stable and push tags
-        if: ${{ !inputs.candidate }}
+        if: ${{ !inputs.candidate && !inputs.test_pypi }}
         run: |
           make check-release
           make git-merge-main-stable
@@ -80,13 +80,13 @@ jobs:
           repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
     
       - name: Bump to next candidate
-        if: ${{ inputs.candidate }}
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           make bumpversion-candidate
           make git-push
     
       - name: Merge to main and bump to next patch
-        if: ${{ !inputs.candidate }}
+        if: ${{ !inputs.candidate && !inputs.test_pypi}}
         run: |
           make git-merge-stable-main
           make bumpversion-patch

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -1,93 +1,26 @@
-# name: Test README
-
-# on:
-#   push:
-#   pull_request:
-#     types: [opened, reopened]
-
-# jobs:
-#   readme:
-#     runs-on: ${{ matrix.os }}
-#     strategy:
-#       matrix:
-#         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-#         os: [ubuntu-latest, macos-latest]
-#     steps:
-#     - uses: actions/checkout@v1
-#     - name: Set up Python ${{ matrix.python-version }}
-#       uses: actions/setup-python@v2
-#       with:
-#         python-version: ${{ matrix.python-version }}
-#     - name: Install dependencies
-#       run: |
-#         python -m pip install --upgrade pip
-#         python -m pip install invoke tomli rundoc .
-#     - name: Run the README.md
-#       run: invoke readme
-name: Release
+name: Test README
 
 on:
-  workflow_dispatch:
-    inputs:
-      candidate:
-        description: 'If true, this creates a release candidate.'
-        required: true
-        type: boolean
-        default: true
-      test_pypi:
-        description: 'If true, this will push to the test pypi instead of regular.'
-        type: boolean
-        default: false
+  push:
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
+  readme:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install dependencies
-        run: |
-            python -m pip install --upgrade pip
-            python -m pip install .[dev]
-
-      - name: Configure Git user
-        run: |
-          git config user.name "SDV Team"
-          git config user.email "dataceboteam@gmail.com"
-          git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
-
-      - name: Merge main to stable and push tags
-        if: ${{ !inputs.candidate && !inputs.test_pypi }}
-        run: |
-          make check-release
-          make git-merge-main-stable
-          make bumpversion-release
-          make git-push-tags-stable
-
-      - name: Create wheel
-        run: |
-          make check-main
-          make dist
-
-      - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
-          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
-    
-      - name: Bump to next candidate
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
-        run: |
-          make bumpversion-candidate
-          make git-push
-    
-      - name: Merge to main and bump to next patch
-        if: ${{ !inputs.candidate && !inputs.test_pypi}}
-        run: |
-          make git-merge-stable-main
-          make bumpversion-patch
-          make git-push
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install invoke tomli rundoc .
+    - name: Run the README.md
+      run: invoke readme

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -1,26 +1,93 @@
-name: Test README
+# name: Test README
+
+# on:
+#   push:
+#   pull_request:
+#     types: [opened, reopened]
+
+# jobs:
+#   readme:
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       matrix:
+#         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+#         os: [ubuntu-latest, macos-latest]
+#     steps:
+#     - uses: actions/checkout@v1
+#     - name: Set up Python ${{ matrix.python-version }}
+#       uses: actions/setup-python@v2
+#       with:
+#         python-version: ${{ matrix.python-version }}
+#     - name: Install dependencies
+#       run: |
+#         python -m pip install --upgrade pip
+#         python -m pip install invoke tomli rundoc .
+#     - name: Run the README.md
+#       run: invoke readme
+name: Release
 
 on:
-  push:
-  pull_request:
-    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: 'If true, this creates a release candidate.'
+        required: true
+        type: boolean
+        default: true
+      test_pypi:
+        description: 'If true, this will push to the test pypi instead of regular.'
+        type: boolean
+        default: false
 
 jobs:
-  readme:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        os: [ubuntu-latest, macos-latest]
+  release:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install invoke tomli rundoc .
-    - name: Run the README.md
-      run: invoke readme
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install .[dev]
+
+      - name: Configure Git user
+        run: |
+          git config user.name "SDV Team"
+          git config user.email "dataceboteam@gmail.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
+
+      - name: Merge main to stable and push tags
+        if: ${{ !inputs.candidate }}
+        run: |
+          make check-release
+          make git-merge-main-stable
+          make bumpversion-release
+          make git-push-tags-stable
+
+      - name: Create wheel
+        run: |
+          make check-main
+          make dist
+
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
+          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
+    
+      - name: Bump to next candidate
+        if: ${{ inputs.candidate }}
+        run: |
+          make bumpversion-candidate
+          make git-push
+    
+      - name: Merge to main and bump to next patch
+        if: ${{ !inputs.candidate }}
+        run: |
+          make git-merge-stable-main
+          make bumpversion-patch
+          make git-push

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   readme:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: 'If true, this creates a release candidate.'
+        required: true
+        type: boolean
+        default: true
+      test_pypi:
+        description: 'If true, this will push to the test pypi instead of regular.'
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install .[dev]
+
+      - name: Configure Git user
+        run: |
+          git config user.name "SDV Team"
+          git config user.email "dataceboteam@gmail.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
+
+      - name: Merge main to stable and push tags
+        if: ${{ !inputs.candidate }}
+        run: |
+          make check-release
+          make git-merge-main-stable
+          make bumpversion-release
+          make git-push-tags-stable
+
+      - name: Create wheel
+        run: |
+          make check-main
+          make dist
+
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
+          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
+    
+      - name: Bump to next candidate
+        if: ${{ inputs.candidate }}
+        run: |
+          make bumpversion-candidate
+          make git-push
+    
+      - name: Merge to main and bump to next patch
+        if: ${{ !inputs.candidate }}
+        run: |
+          make git-merge-stable-main
+          make bumpversion-patch
+          make git-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  release:
+    types: [published]
+
   workflow_dispatch:
     inputs:
       candidate:
@@ -11,13 +14,16 @@ on:
       test_pypi:
         description: 'If true, this will push to the test pypi instead of regular.'
         type: boolean
-        default: false
+        default: true
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.candidate && 'main-clone' || 'stable' }}
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -28,40 +34,49 @@ jobs:
             python -m pip install --upgrade pip
             python -m pip install .[dev]
 
-      - name: Configure Git user
-        run: |
-          git config user.name "SDV Team"
-          git config user.email "dataceboteam@gmail.com"
-          git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
-
-      - name: Merge main to stable and push tags
-        if: ${{ !inputs.candidate && !inputs.test_pypi }}
-        run: |
-          make check-release
-          make git-merge-main-stable
-          make bumpversion-release
-          make git-push-tags-stable
-
       - name: Create wheel
         run: |
-          make check-main
           make dist
 
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
-          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
+          repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
     
       - name: Bump to next candidate
         if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           make bumpversion-candidate
-          make git-push
-    
-      - name: Merge to main and bump to next patch
-        if: ${{ !inputs.candidate && !inputs.test_pypi}}
+
+      - name: Get last commit message
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
+        id: get_message
         run: |
-          make git-merge-stable-main
-          make bumpversion-patch
-          make git-push
+          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          echo "commit_message<<EOF" >> $GITHUB_ENV
+          echo "$COMMIT_MESSAGE" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create PR for candidate
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
+        id: bump-candidate-pr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          commit-message: ${{ env.commit_message }}
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          title: ${{ env.commit_message }}
+          body: "This is an auto-generated PR to bump the version to the next release candidate."
+          branch: bump-release-candidate
+          branch-suffix: short-commit-hash
+          base: main
+
+      - name: Enable Pull Request Automerge
+        if: steps.bump-candidate-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          pull-request-number: ${{ steps.bump-candidate-pr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       candidate:
-        description: 'If true, this creates a release candidate.'
+        description: 'Release candidate.'
         required: true
         type: boolean
         default: true
       test_pypi:
-        description: 'If true, this will push to the test pypi instead of regular.'
+        description: 'Test PyPi.'
         type: boolean
-        default: true
+        default: false
 
 jobs:
   release:
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.candidate && 'main-clone' || 'stable' }}
+          ref: ${{ inputs.candidate && 'main' || 'stable' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -43,55 +43,11 @@ jobs:
         with:
           password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
           repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
-  
-  bump-candidate:
-    if: ${{ inputs.candidate }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: 'main-clone'
 
-      - name: Configure Git user
+      - name: Bump version to next candidate
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install .[dev]
-
-      - name: Bump to next candidate
-        run: |
           make bumpversion-candidate
-
-      - name: Get last commit message
-        id: get_message
-        run: |
-          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
-          echo "commit_message<<EOF" >> $GITHUB_ENV
-          echo "$COMMIT_MESSAGE" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Create PR for candidate
-        id: bump-candidate-pr
-        uses: peter-evans/create-pull-request@v4
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          commit-message: ${{ env.commit_message }}
-          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-          title: ${{ env.commit_message }}
-          body: "This is an auto-generated PR to bump the version to the next release candidate."
-          branch: bump-release-candidate
-          branch-suffix: short-commit-hash
-          base: main
-
-      - name: Enable Pull Request Automerge
-        if: steps.bump-candidate-pr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
-        with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
-          pull-request-number: ${{ steps.bump-candidate-pr.outputs.pull-request-number }}
-          merge-method: squash
+          make git-push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+
       - name: Bump to next candidate
         run: |
           make bumpversion-candidate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,14 +43,25 @@ jobs:
         with:
           password: ${{ inputs.test_pypi && secrets.TEST_PYPI_API_TOKEN || secrets.PYPI_API_TOKEN }}
           repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
-    
+  
+  bump-candidate:
+    if: ${{ inputs.candidate }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: 'main-clone'
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Bump to next candidate
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           make bumpversion-candidate
 
       - name: Get last commit message
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
         id: get_message
         run: |
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
@@ -59,7 +70,6 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create PR for candidate
-        if: ${{ inputs.candidate && !inputs.test_pypi }}
         id: bump-candidate-pr
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GH_ACCESS_TOKEN }}@github.com/${{ github.repository }}
 
       - name: Merge main to stable and push tags
-        if: ${{ !inputs.candidate }}
+        if: ${{ !inputs.candidate && !inputs.test_pypi }}
         run: |
           make check-release
           make git-merge-main-stable
@@ -54,13 +54,13 @@ jobs:
           repository-url: ${{ inputs.test_pypi && 'https://test.pypi.org/legacy/' || 'https://pypi.org' }}
     
       - name: Bump to next candidate
-        if: ${{ inputs.candidate }}
+        if: ${{ inputs.candidate && !inputs.test_pypi }}
         run: |
           make bumpversion-candidate
           make git-push
     
       - name: Merge to main and bump to next patch
-        if: ${{ !inputs.candidate }}
+        if: ${{ !inputs.candidate && !inputs.test_pypi}}
         run: |
           make git-merge-stable-main
           make bumpversion-patch

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and dependencies

--- a/.github/workflows/tutorials.yml
+++ b/.github/workflows/tutorials.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tutorials:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,9 +22,9 @@ jobs:
           - os: macos-latest
             python-version: '3.13'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -262,3 +262,7 @@ release-candidate: check-main publish bumpversion-candidate git-push
 
 .PHONY: release-candidate-test
 release-candidate-test: check-clean check-main publish-test
+
+.PHONY: check-branch
+check-branch:
+	@echo $(CURRENT_BRANCH)

--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,13 @@ publish: dist publish-confirm ## package and upload a release
 
 .PHONY: git-merge-main-stable
 git-merge-main-stable: ## Merge main into stable
-	git checkout stable-clone || git checkout -b stable-clone
-	git merge --no-ff main-clone -m"make release-tag: Merge branch 'main' into stable"
+	git checkout stable || git checkout -b stable
+	git merge --no-ff main -m"make release-tag: Merge branch 'main' into stable"
 
 .PHONY: git-merge-stable-main
 git-merge-stable-main: ## Merge stable into main
-	git checkout main-clone
-	git merge stable-clone
+	git checkout main
+	git merge stable
 
 .PHONY: git-push
 git-push: ## Simply push the repository to github
@@ -184,7 +184,7 @@ git-push: ## Simply push the repository to github
 
 .PHONY: git-push-tags-stable
 git-push-tags-stable: ## Push tags and stable to github
-	git push --tags origin stable-clone
+	git push --tags origin stable
 
 .PHONY: bumpversion-release
 bumpversion-release: ## Bump the version to the next release
@@ -225,21 +225,21 @@ endif
 
 .PHONY: check-main
 check-main: ## Check if we are in main branch
-	ifneq ($(CURRENT_BRANCH),main-clone)
-		$(error Please make the release from main branch\n)
-	endif
+ifneq ($(CURRENT_BRANCH),main)
+	$(error Please make the release from main branch\n)
+endif
 
 .PHONY: check-candidate
 check-candidate: ## Check if a release candidate has been made
-	ifeq ($(CURRENT_VERSION),dev0)
-		$(error Please make a release candidate and test it before atempting a release)
-	endif
+ifeq ($(CURRENT_VERSION),dev0)
+	$(error Please make a release candidate and test it before atempting a release)
+endif
 
 .PHONY: check-history
 check-history: ## Check if HISTORY.md has been modified
-	ifeq ($(CHANGELOG_LINES),0)
-		$(error Please insert the release notes in HISTORY.md before releasing)
-	endif
+ifeq ($(CHANGELOG_LINES),0)
+	$(error Please insert the release notes in HISTORY.md before releasing)
+endif
 
 .PHONY: check-deps
 check-deps: # Dependency targets

--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,9 @@ CHANGELOG_LINES := $(shell git diff HEAD..origin/stable HISTORY.md 2>&1 | wc -l)
 
 .PHONY: check-clean
 check-clean: ## Check if the directory has uncommitted changes
-	ifneq ($(CLEAN_DIR),)
-		$(error There are uncommitted changes)
-	endif
+ifneq ($(CLEAN_DIR),)
+	$(error There are uncommitted changes)
+endif
 
 .PHONY: check-main
 check-main: ## Check if we are in main branch

--- a/Makefile
+++ b/Makefile
@@ -219,27 +219,27 @@ CHANGELOG_LINES := $(shell git diff HEAD..origin/stable HISTORY.md 2>&1 | wc -l)
 
 .PHONY: check-clean
 check-clean: ## Check if the directory has uncommitted changes
-ifneq ($(CLEAN_DIR),)
-	$(error There are uncommitted changes)
-endif
+	ifneq ($(CLEAN_DIR),)
+		$(error There are uncommitted changes)
+	endif
 
 .PHONY: check-main
 check-main: ## Check if we are in main branch
-ifneq ($(CURRENT_BRANCH),main-clone)
-	$(error Please make the release from main branch\n)
-endif
+	ifneq ($(CURRENT_BRANCH),main-clone)
+		$(error Please make the release from main branch\n)
+	endif
 
 .PHONY: check-candidate
 check-candidate: ## Check if a release candidate has been made
-ifeq ($(CURRENT_VERSION),dev0)
-	$(error Please make a release candidate and test it before atempting a release)
-endif
+	ifeq ($(CURRENT_VERSION),dev0)
+		$(error Please make a release candidate and test it before atempting a release)
+	endif
 
 .PHONY: check-history
 check-history: ## Check if HISTORY.md has been modified
-ifeq ($(CHANGELOG_LINES),0)
-	$(error Please insert the release notes in HISTORY.md before releasing)
-endif
+	ifeq ($(CHANGELOG_LINES),0)
+		$(error Please insert the release notes in HISTORY.md before releasing)
+	endif
 
 .PHONY: check-deps
 check-deps: # Dependency targets

--- a/Makefile
+++ b/Makefile
@@ -170,13 +170,13 @@ publish: dist publish-confirm ## package and upload a release
 
 .PHONY: git-merge-main-stable
 git-merge-main-stable: ## Merge main into stable
-	git checkout stable || git checkout -b stable
-	git merge --no-ff main -m"make release-tag: Merge branch 'main' into stable"
+	git checkout stable-clone || git checkout -b stable-clone
+	git merge --no-ff main-clone -m"make release-tag: Merge branch 'main' into stable"
 
 .PHONY: git-merge-stable-main
 git-merge-stable-main: ## Merge stable into main
-	git checkout main
-	git merge stable
+	git checkout main-clone
+	git merge stable-clone
 
 .PHONY: git-push
 git-push: ## Simply push the repository to github
@@ -184,7 +184,7 @@ git-push: ## Simply push the repository to github
 
 .PHONY: git-push-tags-stable
 git-push-tags-stable: ## Push tags and stable to github
-	git push --tags origin stable
+	git push --tags origin stable-clone
 
 .PHONY: bumpversion-release
 bumpversion-release: ## Bump the version to the next release
@@ -225,7 +225,7 @@ endif
 
 .PHONY: check-main
 check-main: ## Check if we are in main branch
-ifneq ($(CURRENT_BRANCH),main)
+ifneq ($(CURRENT_BRANCH),main-clone)
 	$(error Please make the release from main branch\n)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ check-release: check-clean check-candidate check-main check-history ## Check if 
 
 .PHONY: release
 release: check-release git-merge-main-stable bumpversion-release git-push-tags-stable \
-	publish git-merge-stable-main bumpversion-patch git-push
+	git-merge-stable-main bumpversion-patch git-push
 
 .PHONY: release-test
 release-test: check-release git-merge-main-stable bumpversion-release bumpversion-revert

--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,3 @@ release-candidate: check-main publish bumpversion-candidate git-push
 
 .PHONY: release-candidate-test
 release-candidate-test: check-clean check-main publish-test
-
-.PHONY: check-branch
-check-branch:
-	@echo $(CURRENT_BRANCH)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,25 +8,21 @@ The process of releasing a new version involves several steps:
 
 3. [Documentation](#documentation)
 
-4. [Milestone](#milestone)
+4. [Make a release candidate](#make-a-release-candidate)
 
-5. [HISTORY.md](#history.md)
+5. [Integration with SDV](#integration-with-sdv)
 
-6. [Distribution](#distribution)
+6. [Milestone](#milestone)
 
-7. [Integration with SDV](#integration-with-sdv)
+7. [HISTORY.md](#history.md)
 
-7.1. [Install SDV from source](#install-sdv-from-source)
+8. [Distribution](#distribution)
 
-7.2. [Install from distribution](#install-from-distribution)
+9. [Making the release](#making-the-release)
 
-7.3. [Run SDV tests and README.md examples](#run-sdv-tests-and-readme.md-examples)
+9.1. [Tag and release to PyPi](#tag-and-release-to-pypi)
 
-8. [Making the release](#making-the-release)
-
-8.1. [Tag and release to PyPi](#tag-and-release-to-pypi)
-
-8.2. [Update the release on GitHub](#update-the-release-on-github)
+9.2. [Update the release on GitHub](#update-the-release-on-github)
 
 
 ## Install Copulas from source
@@ -128,7 +124,7 @@ git checkout -b test-copulas-X.Y.Z
 git push --set-upstream origin test-copulas-X.Y.Z
 ```
 
-4. Check the [actions][sdv-actions] tab on SDV to make sure all the tests pass.
+4. Check the [Actions][sdv-actions] tab on SDV to make sure all the tests pass.
 
 [sdv-actions]: https://github.com/sdv-dev/SDV/actions
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,6 +94,44 @@ Alternatively, you can simply generate the documentation using the command:
 make docs
 ```
 
+## Make a release candidate
+
+1. On the Copulas GitHub page, navigate to the [Actions][actions] tab.
+2. Select the `Release` action.
+3. Run it on the main branch. Make sure `Release candidate` is checked and `Test PyPi` is not.
+4. Check on [PyPi][copulas-pypi] to assure the release candidate was successfully uploaded.
+
+[actions]: https://github.com/sdv-dev/Copulas/actions
+[copulas-pypi]: https://pypi.org/project/copulas/#history
+
+## Integration with SDV
+
+### Create a branch on SDV to test the candidate
+
+Before doing the actual release, we need to test that the candidate works with SDV. To do this, we can create a branch on SDV that points to the release candidate we just created using the following steps:
+
+1. Create a new branch on the SDV repository.
+
+```bash
+git checkout -b test-copulas-X.Y.Z
+```
+
+2. Update the pyproject.toml to set the minimum version of Copulas to be the same as the version of the release. For example, 
+
+```toml
+'copulas>=X.Y.Z.dev0'
+```
+
+3. Push this branch. This should trigger all the tests to run.
+
+```bash
+git push --set-upstream origin test-copulas-X.Y.Z
+```
+
+4. Check the [actions][sdv-actions] tab on SDV to make sure all the tests pass.
+
+[sdv-actions]: https://github.com/sdv-dev/SDV/actions
+
 ## Milestone
 
 It's important check that the git hub and milestone issues are up to date with the release.
@@ -173,37 +211,6 @@ pip install /path/to/copulas/dist/<copulas-distribution-version-any>.whl
 ```
 
 4. Now you are ready to execute the README.md examples.
-
-## Integration with SDV
-
-### Install SDV from source
-
-Clone the project and install the development requirements. Alternatively, with your virtualenv activated.
-
-```bash
-git clone https://github.com/sdv-dev/SDV
-cd SDV
-git checkout main
-make install-develop
-```
-
-### Install from distribution
-
-Install the Copulas version from the generated distribution file.
-
-```bash
-pip install /path/to/copulas/dist/<copulas-distribution-version-any>.whl
-```
-
-### Run SDV tests and README.md examples
-
-Execute the SDV tests to ensure that the new distribution version works.
-
-```bash
-make test
-```
-
-Also, execute the SDV README.md examples.
 
 ## Making the release
 


### PR DESCRIPTION
resolves #462 

This PR:
- Adds a workflow to push the .whl and .tar.gz files to PyPi when a Github release is made
    - This workflow has options to push to the test PyPi as well as a release a candidate
    - If the candidate option is checked, it will bump the version to the next candidate and push that commit
- Updates the Release.md to add directions for making and testing the release candidate
- Updates the makefile to not push the files to PyPi anymore since the workflow will do it.
- Updates the actions versions of workflows
- Adds cancellation to workflows that are already being run

[Here](https://github.com/sdv-dev/Copulas/actions/runs/14722321405) is an example of the workflow run with a candidate and test pypi set to True. You can see it pushed to a clone of the main branch [here](https://github.com/sdv-dev/Copulas/commit/50ae2f483d4a0e532b20bf414f049e3b7eab36c4).

[Here](https://github.com/sdv-dev/Copulas/actions/runs/14721940805) is an example of the workflow run with an actual release and test pypi set to True.