### PR TITLE
Bump version: 0.12.4.dev2 → 0.12.4.dev3

### DIFF
--- a/copulas/__init__.py
+++ b/copulas/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = 'DataCebo, Inc.'
 __email__ = 'info@sdv.dev'
-__version__ = '0.12.3.dev0'
+__version__ = '0.12.4.dev3'
 
 import sys
 import warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ namespaces = false
 ]
 
 [tool.bumpversion]
-current_version = "0.12.3.dev0"
+current_version = "0.12.4.dev3"
 commit = true
 tag = true
 parse = '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<candidate>\d+))?'


### PR DESCRIPTION
This is an auto-generated PR to bump the version to the next release candidate.