### PR TITLE
Make `BetaUnivariate` reject fitted parameters that obviously don’t match the data 

### DIFF
--- a/tests/end-to-end/univariate/test_beta.py
+++ b/tests/end-to-end/univariate/test_beta.py
@@ -3,6 +3,7 @@ import tempfile
 from unittest import TestCase
 
 import numpy as np
+import pytest
 from scipy.stats import beta
 
 from copulas.univariate import BetaUnivariate
@@ -42,6 +43,67 @@ class TestGaussian(TestCase):
 
         assert model._constant_value == 5
         np.testing.assert_equal(np.full(50, 5), model.sample(50))
+
+    def test_fit_raises(self):
+        """Test it for dataset that fails."""
+        model = BetaUnivariate()
+        data = np.array([  # From GH #472
+            3.337169,
+            6.461266,
+            4.871053,
+            4.206772,
+            5.157541,
+            3.437069,
+            6.712143,
+            5.135402,
+            6.453203,
+            4.623059,
+            5.827161,
+            5.291858,
+            5.571134,
+            5.441359,
+            4.816826,
+            3.277817,
+            4.215228,
+            4.48338,
+            4.345968,
+            6.125759,
+            4.860464,
+            6.511877,
+            3.959057,
+            4.882996,
+            6.058503,
+            3.337436,
+            5.06921,
+            4.414371,
+            4.564768,
+            5.1014,
+            4.161663,
+            5.757317,
+            4.032375,
+            3.907653,
+            4.269559,
+            4.08505,
+            6.811531,
+            5.02597,
+            5.438358,
+            3.44442,
+            3.462209,
+            4.871354,
+            5.947369,
+            4.167546,
+            4.692054,
+            5.542011,
+            4.926634,
+            4.491286,
+            5.344663,
+            4.526089,
+            1.645776,
+        ])
+
+        err_msg = 'Converged parameters for beta distribution have a near-zero range.'
+        with pytest.raises(ValueError, match=err_msg):
+            model.fit(data)
 
     def test_pdf(self):
         model = BetaUnivariate()

--- a/tests/unit/univariate/test_beta.py
+++ b/tests/unit/univariate/test_beta.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 from scipy.stats import beta
 
 from copulas.univariate import BetaUnivariate
@@ -24,6 +25,46 @@ class TestBetaUnivariate(TestCase):
         expected = {'loc': 1, 'scale': 1, 'a': 1, 'b': 1}
         for key, value in distribution._params.items():
             np.testing.assert_allclose(value, expected[key], atol=0.3)
+
+    @patch('copulas.univariate.beta.beta')
+    def test__fit_raises_value_error_if_scale_is_near_zero(self, mock_beta):
+        mock_beta.fit.return_value = (1, 0, 1, 1e-8)
+        distribution = BetaUnivariate()
+
+        data = np.array([1, 2, 3, 4])
+        err_msg = 'Converged parameters for beta distribution have a near-zero range.'
+        with pytest.raises(ValueError, match=err_msg):
+            distribution._fit(data)
+
+        mock_beta.fit.assert_called_once_with(data, loc=1, scale=3)
+
+    @patch('copulas.univariate.beta.beta')
+    def test__fit_raises_value_error_if_parameters_are_higher_than_range(self, mock_beta):
+        mock_beta.fit.return_value = (5, 1, 5, 1)
+        distribution = BetaUnivariate()
+
+        data = np.array([7, 8, 9, 10])
+        err_msg = (
+            'Converged parameters for beta distribution are outside the min/max range of the data.'
+        )
+        with pytest.raises(ValueError, match=err_msg):
+            distribution._fit(data)
+
+        mock_beta.fit.assert_called_once_with(data, loc=7, scale=3)
+
+    @patch('copulas.univariate.beta.beta')
+    def test__fit_raises_value_error_if_parameters_are_lower_than_range(self, mock_beta):
+        mock_beta.fit.return_value = (5, 1, 5, 1)
+        distribution = BetaUnivariate()
+
+        data = np.array([1, 2, 3, 4])
+        err_msg = (
+            'Converged parameters for beta distribution are outside the min/max range of the data.'
+        )
+        with pytest.raises(ValueError, match=err_msg):
+            distribution._fit(data)
+
+        mock_beta.fit.assert_called_once_with(data, loc=1, scale=3)
 
     def test__is_constant_true(self):
         distribution = BetaUnivariate()


### PR DESCRIPTION
CU-86b52ccx2, Resolve #472.